### PR TITLE
Update LinqExecutor signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ var syntax = src.Parse("AccountName startswith 'alice' and Created gt '2019-01-0
 var sql = syntax.ToSqlServerCommand(_source, query);
 ... execute SQL via whatever method you prefer ...
 
-// To execute via an in-memory object collection
-var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query.filter, list);
+// To execute via an in-memory object collection using LINQ
+var results = syntax.QueryCollection<EmployeeObj>(list);
 ```
 
 # How can I implement Searchlight using Dapper and AutoMapper to maintain full database independence?

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.8.5</version>
+		<version>0.8.6</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -11,7 +11,9 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Implements the Searchlight REST query language for CSharp.  The Searchlight language is database neutral and can support most database technologies.  Using Searchlight, you can provide a rich query language via your API, while still being completely safe from SQL injection attacks.  Searchlight enables you to use multiple database engines with the same functionality, and to transform queries using the in-memory abstract syntax tree prior to execution.</description>
 		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
-		<releaseNotes>Initial release implements abstract symbol tree parser for the Searchlight language as well as executors for SQL-like databases and in-memory collection objects queried using LINQ.</releaseNotes>
+		<releaseNotes>
+			Update the method signature for LINQ querying to be similar to SQL.
+		</releaseNotes>
 		<copyright>Copyright 2013 - 2021</copyright>
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-searchlight" />

--- a/Searchlight.sln
+++ b/Searchlight.sln
@@ -4,13 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.31112.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0B19EEE6-D7BF-41CD-884A-6EB31698DCAA}"
-ProjectSection(SolutionItems) = preProject
-	Searchlight.nuspec = Searchlight.nuspec
-EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Searchlight", "src\Searchlight\Searchlight.csproj", "{CEE9DFAC-4ABE-4558-B9C0-3FD16FFED3AB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Searchlight.Tests", "tests\Searchlight.Tests\Searchlight.Tests.csproj", "{C87B0E18-33A4-43FC-BCE7-C0343FC60228}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other Files", "Other Files", "{6FA550FB-FF83-4552-A9C0-3F7C2736385D}"
+ProjectSection(SolutionItems) = preProject
+	Searchlight.nuspec = Searchlight.nuspec
+	README.md = README.md
+EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -7,28 +7,27 @@ using Searchlight.Query;
 
 namespace Searchlight
 {
-    public class LinqExecutor
+    public static class LinqExecutor
     {
         /// <summary>
-        /// Query against a collection in memory
+        /// Run the query represented by this syntax tree against an in-memory collection using LINQ
         /// </summary>
-        /// <typeparam name="T">Underlying data type being queried</typeparam>
-        /// <param name="src">Information about the data source</param>
-        /// <param name="query">The query commands</param>
-        /// <param name="list">The source enumerable</param>
+        /// <param name="tree">The syntax tree of the query to execute</param>
+        /// <param name="collection">The collection of data elements to query</param>
+        /// <typeparam name="T">Generic type of the model</typeparam>
         /// <returns></returns>
-        public static IEnumerable<T> QueryCollection<T>(DataSource src, List<BaseClause> query, IEnumerable<T> list)
+        public static IEnumerable<T> QueryCollection<T>(this SyntaxTree tree, IEnumerable<T> collection)
         {
             // Goal of this function is to construct this LINQ expression:
             //   return (from obj in LIST where QUERY select obj)
             // Here's how we'll do it:
-            var queryable = list.AsQueryable<T>();
+            var queryable = collection.AsQueryable<T>();
 
             // Construct a linq "select" expression (
             ParameterExpression select = Expression.Parameter(typeof(T), "obj");
 
             // Construct a linq "filter" expression 
-            Expression expression = BuildExpression(select, query, src);
+            Expression expression = BuildExpression(select, tree.Filter, tree.Source);
 
             // Convert that to a "where" method call
             var whereCallExpression = Expression.Call(

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -44,19 +44,19 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Construct a simple query and check that it comes out correct
-            var query = src.ParseFilter("id gt 1 and paycheck le 1000");
-            Assert.AreEqual(2, query.Count());
-            Assert.AreEqual(ConjunctionType.AND, query[0].Conjunction);
-            Assert.AreEqual("id", ((CriteriaClause)query[0]).Column.FieldName);
-            Assert.AreEqual(OperationType.GreaterThan, ((CriteriaClause)query[0]).Operation);
-            Assert.AreEqual(1, ((CriteriaClause)query[0]).Value);
-            Assert.AreEqual("paycheck", ((CriteriaClause)query[1]).Column.FieldName);
-            Assert.AreEqual(OperationType.LessThanOrEqual, ((CriteriaClause)query[1]).Operation);
-            Assert.AreEqual(1000.0m, ((CriteriaClause)query[1]).Value);
+            var syntax = src.Parse("id gt 1 and paycheck le 1000");
+            Assert.AreEqual(2, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.AND, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("id", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(OperationType.GreaterThan, ((CriteriaClause)syntax.Filter[0]).Operation);
+            Assert.AreEqual(1, ((CriteriaClause)syntax.Filter[0]).Value);
+            Assert.AreEqual("paycheck", ((CriteriaClause)syntax.Filter[1]).Column.FieldName);
+            Assert.AreEqual(OperationType.LessThanOrEqual, ((CriteriaClause)syntax.Filter[1]).Operation);
+            Assert.AreEqual(1000.0m, ((CriteriaClause)syntax.Filter[1]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 3);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(3, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.id > 1);
@@ -71,15 +71,15 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Construct a simple query and check that it comes out correct
-            var query = src.ParseFilter("id gt 1 and (paycheck lt 1000 or paycheck gt 1000)");
-            Assert.AreEqual(2, query.Count());
-            Assert.AreEqual(ConjunctionType.AND, query[0].Conjunction);
-            Assert.AreEqual("id", ((CriteriaClause)query[0]).Column.FieldName);
-            Assert.AreEqual(OperationType.GreaterThan, ((CriteriaClause)query[0]).Operation);
-            Assert.AreEqual(1, ((CriteriaClause)query[0]).Value);
+            var syntax = src.Parse("id gt 1 and (paycheck lt 1000 or paycheck gt 1000)");
+            Assert.AreEqual(2, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.AND, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("id", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(OperationType.GreaterThan, ((CriteriaClause)syntax.Filter[0]).Operation);
+            Assert.AreEqual(1, ((CriteriaClause)syntax.Filter[0]).Value);
 
             // Did we get a nested clause?
-            var cc = query[1] as CompoundClause;
+            var cc = syntax.Filter[1] as CompoundClause;
             Assert.IsNotNull(cc);
             Assert.AreEqual(2, cc.Children.Count);
             Assert.AreEqual("paycheck", ((CriteriaClause)cc.Children[0]).Column.FieldName);
@@ -90,8 +90,8 @@ namespace Searchlight.Tests
             Assert.AreEqual(1000.0m, ((CriteriaClause)cc.Children[1]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 2);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(2, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.id > 1);
@@ -105,16 +105,16 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Note that the "between" clause is inclusive
-            var query = src.ParseFilter("id between 2 and 4");
-            Assert.AreEqual(1, query.Count());
-            Assert.AreEqual(ConjunctionType.NONE, query[0].Conjunction);
-            Assert.AreEqual("id", ((BetweenClause)query[0]).Column.FieldName);
-            Assert.AreEqual(2, ((BetweenClause)query[0]).LowerValue);
-            Assert.AreEqual(4, ((BetweenClause)query[0]).UpperValue);
+            var syntax = src.Parse("id between 2 and 4");
+            Assert.AreEqual(1, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("id", ((BetweenClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(2, ((BetweenClause)syntax.Filter[0]).LowerValue);
+            Assert.AreEqual(4, ((BetweenClause)syntax.Filter[0]).UpperValue);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 3);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(3, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.id > 1);
@@ -128,16 +128,16 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Note that the "between" clause is inclusive
-            var query = src.ParseFilter("name startswith 'A'");
-            Assert.AreEqual(1, query.Count());
-            Assert.AreEqual(ConjunctionType.NONE, query[0].Conjunction);
-            Assert.AreEqual("name", ((CriteriaClause)query[0]).Column.FieldName);
-            Assert.AreEqual(OperationType.StartsWith, ((CriteriaClause)query[0]).Operation);
-            Assert.AreEqual("A", ((CriteriaClause)query[0]).Value);
+            var syntax = src.Parse("name startswith 'A'");
+            Assert.AreEqual(1, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(OperationType.StartsWith, ((CriteriaClause)syntax.Filter[0]).Operation);
+            Assert.AreEqual("A", ((CriteriaClause)syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 1);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(1, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.name[0] == 'A');
@@ -150,16 +150,16 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Note that the "between" clause is inclusive
-            var query = src.ParseFilter("name endswith 's'");
-            Assert.AreEqual(1, query.Count());
-            Assert.AreEqual(ConjunctionType.NONE, query[0].Conjunction);
-            Assert.AreEqual("name", ((CriteriaClause)query[0]).Column.FieldName);
-            Assert.AreEqual(OperationType.EndsWith, ((CriteriaClause)query[0]).Operation);
-            Assert.AreEqual("s", ((CriteriaClause)query[0]).Value);
+            var syntax = src.Parse("name endswith 's'");
+            Assert.AreEqual(1, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(OperationType.EndsWith, ((CriteriaClause)syntax.Filter[0]).Operation);
+            Assert.AreEqual("s", ((CriteriaClause)syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 2);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(2, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.name.EndsWith("s"));
@@ -173,16 +173,16 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             // Note that the "between" clause is inclusive
-            var query = src.ParseFilter("name contains 's'");
-            Assert.AreEqual(1, query.Count());
-            Assert.AreEqual(ConjunctionType.NONE, query[0].Conjunction);
-            Assert.AreEqual("name", ((CriteriaClause)query[0]).Column.FieldName);
-            Assert.AreEqual(OperationType.Contains, ((CriteriaClause)query[0]).Operation);
-            Assert.AreEqual("s", ((CriteriaClause)query[0]).Value);
+            var syntax = src.Parse("name contains 's'");
+            Assert.AreEqual(1, syntax.Filter.Count());
+            Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
+            Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
+            Assert.AreEqual(OperationType.Contains, ((CriteriaClause)syntax.Filter[0]).Operation);
+            Assert.AreEqual("s", ((CriteriaClause)syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = LinqExecutor.QueryCollection<EmployeeObj>(src, query, list);
-            Assert.IsTrue(results.Count() == 3);
+            var results = syntax.QueryCollection<EmployeeObj>(list).ToArray();
+            Assert.AreEqual(3, results.Length);
             foreach (var e in results)
             {
                 Assert.IsTrue(e.name.Contains("s"));


### PR DESCRIPTION
The method signature of LinqExecutor was ugly.

Let's update it to be more like SqlExecutor.