### PR TITLE
Refactor and fix issues with DefaultSort

### DIFF
--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -265,27 +265,22 @@ namespace Searchlight
         public List<SortInfo> ParseOrderBy(string orderBy)
         {
             List<SortInfo> list = new List<SortInfo>();
-
-            // Shortcut for case where user gives us an empty string
             if (String.IsNullOrWhiteSpace(orderBy))
             {
-                if (!String.IsNullOrWhiteSpace(DefaultSort))
-                {
-                    list.Add(new SortInfo()
-                    {
-                        Direction = SortDirection.Ascending,
-                        Column = IdentifyColumn(DefaultSort)
-                    });
-                }
+                orderBy = DefaultSort;
+            }
+
+            // If no sort is specified
+            if (String.IsNullOrWhiteSpace(orderBy))
+            {
                 return list;
             }
 
             // Okay, let's tokenize the orderBy statement and begin parsing
             var tokens = Tokenizer.GenerateTokens(orderBy);
-            SortInfo si = null;
             while (tokens.Count > 0)
             {
-                si = new SortInfo();
+                var si = new SortInfo();
                 si.Direction = SortDirection.Ascending;
                 list.Add(si);
 

--- a/src/Searchlight/SqlQuery.cs
+++ b/src/Searchlight/SqlQuery.cs
@@ -1,14 +1,15 @@
 using System.Collections.Generic;
 using System.Text;
+using Searchlight.Query;
 
 namespace Searchlight {
     public class SqlQuery
     {
+        public SyntaxTree Syntax { get; set; }
+        
         public SqlQuery()
         {
             Parameters = new Dictionary<string, object>();
-            WhereClause = new StringBuilder();
-            OrderByClause = new StringBuilder();
             ResultSetClauses = new List<string>();
         }
 
@@ -16,13 +17,13 @@ namespace Searchlight {
 
         public Dictionary<string, object> Parameters { get; }
 
-        public StringBuilder WhereClause { get; }
-        public StringBuilder OrderByClause { get; }
+        public string WhereClause { get; set;  }
+        public string OrderByClause { get; set;  }
         public List<string> ResultSetClauses { get; }
 
         internal string AddParameter(object p)
         {
-            int num = Parameters.Count + 1;
+            var num = Parameters.Count + 1;
             var name = $"@p{num}";
             Parameters.Add(name, p);
             return name;

--- a/tests/Searchlight.Tests/DataSourceTests.cs
+++ b/tests/Searchlight.Tests/DataSourceTests.cs
@@ -33,6 +33,30 @@ namespace Searchlight.Tests
         }
 
         [TestMethod]
+        public void ParseSortPatterns()
+        {
+            var list = _source.ParseOrderBy("a");
+            Assert.AreEqual(1, list.Count);
+            Assert.AreEqual("a", list[0].Column.FieldName);
+            Assert.AreEqual(SortDirection.Ascending, list[0].Direction);
+            
+            list = _source.ParseOrderBy("a, b desc");
+            Assert.AreEqual(2, list.Count);
+            Assert.AreEqual("a", list[0].Column.FieldName);
+            Assert.AreEqual(SortDirection.Ascending, list[0].Direction);
+            Assert.AreEqual("b", list[1].Column.FieldName);
+            Assert.AreEqual(SortDirection.Descending, list[1].Direction);
+
+            _source.DefaultSort = "a, b desc";
+            list = _source.ParseOrderBy("");
+            Assert.AreEqual(2, list.Count);
+            Assert.AreEqual("a", list[0].Column.FieldName);
+            Assert.AreEqual(SortDirection.Ascending, list[0].Direction);
+            Assert.AreEqual("b", list[1].Column.FieldName);
+            Assert.AreEqual(SortDirection.Descending, list[1].Direction);
+        }
+
+        [TestMethod]
         public void AllParenthesis()
         {
             // Basic problem: if you never close a parenthesis that's a syntax error


### PR DESCRIPTION
Let's update SqlExecutor to be a bit more functional and have fewer side effects.  This can potentially allow us to evaluate individual parsing clauses directly.

Let's add some more tests for more complex nested clauses, and correctly fall back to DefaultSort if no order by clause is specified.