### PR TITLE
Update the system to handle intrinsic data types

### DIFF
--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -92,7 +92,7 @@ namespace Searchlight
         {
             Expression field;
             Expression value;
-            
+
             switch (clause)
             {
                 case CriteriaClause criteria:
@@ -148,26 +148,28 @@ namespace Searchlight
 
                 case BetweenClause betweenClause:
                     field = Expression.Property(@select, betweenClause.Column.FieldName);
-                    Expression lowerValue = Expression.Constant(betweenClause.LowerValue, betweenClause.Column.FieldType);
-                    Expression upperValue = Expression.Constant(betweenClause.UpperValue, betweenClause.Column.FieldType);
+                    Expression lowerValue =
+                        Expression.Constant(betweenClause.LowerValue, betweenClause.Column.FieldType);
+                    Expression upperValue =
+                        Expression.Constant(betweenClause.UpperValue, betweenClause.Column.FieldType);
                     Expression lower = Expression.GreaterThanOrEqual(field, lowerValue);
                     Expression upper = Expression.LessThanOrEqual(field, upperValue);
                     return Expression.And(lower, upper);
-                
+
                 case CompoundClause compoundClause:
                     return BuildExpression(select, compoundClause.Children, src);
-                
+
                 case InClause inClause:
-                    field = Expression.Property(@select, inClause.Column.FieldName);
+                    field = Expression.Convert(Expression.Property(@select, inClause.Column.FieldName), typeof(object));
                     value = Expression.Constant(inClause.Values, typeof(List<object>));
                     return Expression.Call(value,
                         typeof(List<object>).GetMethod("Contains", new Type[] {typeof(object)}),
                         field);
-                
+
                 case IsNullClause isNullClause:
                     field = Expression.Property(@select, isNullClause.Column.FieldName);
                     return Expression.Equal(field, Expression.Constant(null));
-                
+
                 default:
                     throw new NotImplementedException();
             }

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -304,20 +304,20 @@ namespace Searchlight.Tests
         }
 
 
-        // [TestMethod]
-        // public void InQueryInts()
-        // {
-        //     var list = GetTestList();
-        //     // getting not implemented error on this line
-        //     // make sure using right formatting, if so then in operator needs adjustment
-        //     var syntax = src.Parse("id in (1,2,57)");
-        //
-        //     var result = syntax.QueryCollection<EmployeeObj>(list);
-        //     
-        //     Assert.IsTrue(result.Any(p => p.id == 1));
-        //     Assert.IsTrue(result.Any(p => p.id == 2));
-        //     Assert.IsNotNull(result);
-        //     Assert.AreEqual(2, result.Count());
-        // }
+        [TestMethod]
+        public void InQueryInts()
+        {
+            var list = GetTestList();
+            // getting not implemented error on this line
+            // make sure using right formatting, if so then in operator needs adjustment
+            var syntax = src.Parse("id in (1,2,57)");
+
+            var result = syntax.QueryCollection<EmployeeObj>(list);
+
+            Assert.IsTrue(result.Any(p => p.id == 1));
+            Assert.IsTrue(result.Any(p => p.id == 2));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+        }
     }
 }


### PR DESCRIPTION
This allows `EmployeeId in [1, 2, 3]` to be evaluated with the linq executor