### PR TITLE
Use Ordinal instead of CurrentCulture for string comparisons

### DIFF
--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -115,7 +115,7 @@ namespace Searchlight
                             return Expression.TryCatch(
                                 Expression.Call(field,
                                     typeof(string).GetMethod("StartsWith", new Type[] {typeof(string), typeof(StringComparison)}), 
-                                    value, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)),
+                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );
@@ -124,7 +124,7 @@ namespace Searchlight
                             return Expression.TryCatch(
                                 Expression.Call(field,
                                     typeof(string).GetMethod("EndsWith", new Type[] {typeof(string), typeof(StringComparison)}),
-                                    value, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)),
+                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );
@@ -132,7 +132,7 @@ namespace Searchlight
                             return Expression.TryCatch(
                                 Expression.Call(field,
                                     typeof(string).GetMethod("Contains", new Type[] {typeof(string), typeof(StringComparison)}),
-                                    value, Expression.Constant(StringComparison.CurrentCultureIgnoreCase)),
+                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -319,5 +319,19 @@ namespace Searchlight.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(2, result.Count());
         }
+
+        [TestMethod]
+        public void InQueryDecimals()
+        {
+            var list = GetTestList();
+
+            var syntax = src.Parse("paycheck in (578.00, 1.234)");
+
+            var result = syntax.QueryCollection(list);
+            
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.ToList()[0].id == 7);
+        }
     }
 }

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -187,7 +187,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(2, results.Length);
             foreach (var e in results)
             {
-                Assert.IsTrue(e.name.EndsWith("s", StringComparison.CurrentCultureIgnoreCase));
+                Assert.IsTrue(e.name.EndsWith("s", StringComparison.OrdinalIgnoreCase));
             }
         }
 
@@ -211,7 +211,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(6, resultsArr.Length);
             foreach (var e in resultsArr)
             {
-                Assert.IsTrue(e.name.Contains("s", StringComparison.CurrentCultureIgnoreCase));
+                Assert.IsTrue(e.name.Contains("s", StringComparison.OrdinalIgnoreCase));
             }
         }
 


### PR DESCRIPTION
Using Ordinal should improve performance per the .NET Standards
https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings