### PR TITLE
Created InvalidOperation Exception

### DIFF
--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -538,6 +538,17 @@ namespace Searchlight
                         throw new FieldTypeMismatch(c.Column.FieldName, c.Column.FieldType.ToString(), Convert.ToString(c.Value), filter);
                     }
                 }
+
+                if (c.Operation == OperationType.GreaterThan || c.Operation == OperationType.GreaterThanOrEqual ||
+                    c.Operation == OperationType.LessThan || c.Operation == OperationType.LessThanOrEqual)
+                {
+                    if (c.Column.FieldType == typeof(string))
+                    {
+                        throw new InvalidOperation(c.Column.FieldName, c.Column.FieldType.ToString(),
+                            Convert.ToString(c.Value), c.Value.GetType().ToString(), filter);
+                    }
+                    
+                }
                 return c;
             }
         }

--- a/src/Searchlight/Exceptions/InvalidOperation.cs
+++ b/src/Searchlight/Exceptions/InvalidOperation.cs
@@ -1,0 +1,24 @@
+﻿namespace Searchlight
+{
+    /// <summary>
+    /// Represents an invalid operation
+    /// </summary>
+    public class InvalidOperation : SearchlightException
+    {
+        public InvalidOperation(string fieldName, string fieldType, string fieldValue, string fieldValueType,
+            string originalFilter)
+        {
+            OriginalFilter = originalFilter;
+            FieldName = fieldName;
+            FieldType = fieldType;
+            FieldValue = fieldValue;
+            FieldValueType = fieldValueType;
+        }
+        
+        public string OriginalFilter { get; set; }
+        public string FieldName { get; set; }
+        public string FieldValue { get; set; }
+        public string FieldType { get; set; }
+        public string FieldValueType { get; set; }
+    }
+}

--- a/tests/Searchlight.Tests/DataSourceTests.cs
+++ b/tests/Searchlight.Tests/DataSourceTests.cs
@@ -31,6 +31,18 @@ namespace Searchlight.Tests
             Assert.AreEqual("Hello!", ex.FieldValue);
             Assert.AreEqual(originalFilter, ex.OriginalFilter);
         }
+        
+        [TestMethod]
+        public void InvalidOperation()
+        {
+            string originalFilter = "a gt 'abc'";
+            var ex = Assert.ThrowsException<InvalidOperation>(() => _source.ParseFilter(originalFilter));
+            Assert.AreEqual("a", ex.FieldName);
+            Assert.AreEqual("System.String", ex.FieldType);
+            Assert.AreEqual("abc", ex.FieldValue);
+            Assert.AreEqual("System.String", ex.FieldValueType);
+            Assert.AreEqual(originalFilter, ex.OriginalFilter);
+        }
 
         [TestMethod]
         public void ParseSortPatterns()

--- a/tests/Searchlight.Tests/SqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/SqlExecutorTests.cs
@@ -165,17 +165,17 @@ namespace Searchlight.Tests
             // Try all basic query expression types - should succeed
             Assert.AreEqual("a = @p1", ParseWhereClause("a = 'test'"));
             Assert.AreEqual("a = @p1", ParseWhereClause("a eq 'test'"));
-            Assert.AreEqual("a > @p1", ParseWhereClause("a > 'test'"));
-            Assert.AreEqual("a > @p1", ParseWhereClause("a gt 'test'"));
-            Assert.AreEqual("a >= @p1", ParseWhereClause("a >= 'test'"));
-            Assert.AreEqual("a >= @p1", ParseWhereClause("a ge 'test'"));
+            Assert.AreEqual("b > @p1", ParseWhereClause("b > 123"));
+            Assert.AreEqual("b > @p1", ParseWhereClause("b gt 123"));
+            Assert.AreEqual("b >= @p1", ParseWhereClause("b >= 123"));
+            Assert.AreEqual("b >= @p1", ParseWhereClause("b ge 123"));
             Assert.AreEqual("a <> @p1", ParseWhereClause("a <> 'test'"));
             Assert.AreEqual("a <> @p1", ParseWhereClause("a != 'test'"));
             Assert.AreEqual("a <> @p1", ParseWhereClause("a ne 'test'"));
-            Assert.AreEqual("a < @p1", ParseWhereClause("a < 'test'"));
-            Assert.AreEqual("a < @p1", ParseWhereClause("a lt 'test'"));
-            Assert.AreEqual("a <= @p1", ParseWhereClause("a <= 'test'"));
-            Assert.AreEqual("a <= @p1", ParseWhereClause("a le 'test'"));
+            Assert.AreEqual("b < @p1", ParseWhereClause("b < 123"));
+            Assert.AreEqual("b < @p1", ParseWhereClause("b lt 123"));
+            Assert.AreEqual("b <= @p1", ParseWhereClause("b <= 123"));
+            Assert.AreEqual("b <= @p1", ParseWhereClause("b le 123"));
 
             // Try slightly more complex query expression types - should succeed
             Assert.AreEqual("a BETWEEN @p1 AND @p2", ParseWhereClause("a between 'test1' and 'test9'"));


### PR DESCRIPTION
For #35, it does not look like C# supports >, < ,>=, or <= for string comparison. Instead, created new SearchlightException, InvalidOperation, for string comparison via gt, lt, ge, le to no longer receive System.InvalidOperationException. Added a check and throw of new exception to DataSource.ParseOneClause.