### PR TITLE
Fix IN operator for empty lists

### DIFF
--- a/src/Searchlight/Exceptions/EmptyClause.cs
+++ b/src/Searchlight/Exceptions/EmptyClause.cs
@@ -14,7 +14,7 @@ namespace Searchlight
         /// <param name="originalFilter"></param>
         public EmptyClause(string originalFilter)
         {
-            this.OriginalFilter = originalFilter;
+            OriginalFilter = originalFilter;
         }
 
         public string OriginalFilter { get; set; }

--- a/src/Searchlight/SqlQuery.cs
+++ b/src/Searchlight/SqlQuery.cs
@@ -17,7 +17,7 @@ namespace Searchlight {
 
         public Dictionary<string, object> Parameters { get; }
 
-        public string WhereClause { get; set;  }
+        public string WhereClause { get; set; }
         public string OrderByClause { get; set;  }
         public List<string> ResultSetClauses { get; }
 

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -319,5 +319,19 @@ namespace Searchlight.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(2, result.Count());
         }
+
+        [TestMethod]
+        public void InQueryDecimals()
+        {
+            var list = GetTestList();
+
+            var syntax = src.Parse("paycheck in (578.00, 1.234)");
+
+            var result = syntax.QueryCollection(list);
+            
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.ToList()[0].id == 7);
+        }
     }
 }

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -328,10 +328,17 @@ namespace Searchlight.Tests
             var syntax = src.Parse("paycheck in (578.00, 1.234)");
 
             var result = syntax.QueryCollection(list);
-            
+
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Any());
             Assert.IsTrue(result.ToList()[0].id == 7);
+        }
+        
+        [TestMethod]
+        public void InQueryEmptyList()
+        {
+            Assert.ThrowsException<EmptyClause>(() => src.Parse("name in ()"));
+            Assert.ThrowsException<EmptyClause>(() => src.Parse("paycheck > 1 AND name in ()"));
         }
     }
 }


### PR DESCRIPTION
Using IN on an empty list now throws an EmptyClause exception instead of a NullReference.
Refactor parts of DataSource
Formatting on a couple files
Closes #41