### PR TITLE
Made LINQ executor case insensitive

### DIFF
--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,3 +1,8 @@
+# 0.9.6
+September 19, 2021
+
+* LINQ executor now uses case insensitive string comparison correctly
+
 # 0.9.5
 September 19, 2021
 

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.9.5</version>
+		<version>0.9.6</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -12,11 +12,10 @@
 		<description>Implements the Searchlight REST query language for CSharp.  The Searchlight language is database neutral and can support most database technologies.  Using Searchlight, you can provide a rich query language via your API, while still being completely safe from SQL injection attacks.  Searchlight enables you to use multiple database engines with the same functionality, and to transform queries using the in-memory abstract syntax tree prior to execution.</description>
 		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
 		<releaseNotes>
-			# 0.9.5
+			# 0.9.6
 			September 19, 2021
 
-			* Added support for SearchlightFlags, a system you can use to detect options selected via the "$include" parameter
-			* Added tests for flags and refactored the CommandCollection system for faster processing
+			* LINQ executor now uses case insensitive string comparison correctly
 		</releaseNotes>
 		<copyright>Copyright 2013 - 2021</copyright>
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>

--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -102,7 +102,15 @@ namespace Searchlight
                     switch (criteria.Operation)
                     {
                         case OperationType.Equals:
-                            return Expression.Equal(field, value);
+                            if (field.Type == typeof(string))
+                            {
+                                return Expression.Call(null,
+                                    typeof(string).GetMethod("Equals", new Type[] { typeof(string), typeof(string), typeof(StringComparison) }),
+                                    field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                            } else
+                            {
+                                return Expression.Equal(field, value);
+                            }
                         case OperationType.GreaterThan:
                             if (field.Type == typeof(string))
                             {

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -427,5 +427,19 @@ namespace Searchlight.Tests
             Assert.ThrowsException<EmptyClause>(() => src.Parse("name in ()"));
             Assert.ThrowsException<EmptyClause>(() => src.Parse("paycheck > 1 AND name in ()"));
         }
+
+        [TestMethod]
+        public void StringEqualsCaseInsensitive()
+        {
+            var list = GetTestList();
+
+            var syntax = src.Parse("name eq 'ALICE SMITH'");
+
+            var result = syntax.QueryCollection<EmployeeObj>(list);
+
+            Assert.IsTrue(result.Any(p => p.name == "Alice Smith"));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count());
+        }
     }
 }


### PR DESCRIPTION
Reported by @AlexRussak in issue #44 

Added a unit test to verify that case insensitive string comparison on the LINQ executor behaves as intended