### PR TITLE
Remove reference to Dapper

### DIFF
--- a/src/Searchlight/Searchlight.csproj
+++ b/src/Searchlight/Searchlight.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.78" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="Exceptions\FilterException.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Dapper was once, many years ago, required to build Searchlight.
Now that Searchlight supports non-SQL databases, this isn't appropriate - not everyone wants to include Dapper in their MongoDB installation.  Let's remove this package reference.