### PR TITLE
Fixed issues with searchlight flags: multiple usage and null aliases

### DIFF
--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,7 +1,14 @@
+# 0.9.9
+September 23, 2021
+
+* Fixed bug with foreign table SQL requesting data for multiple tables
+* Added tests to verify that multiple searchlight flags work as expected
+* Fixed issue where a searchlight flag without aliases caused a crash
+
 # 0.9.8
 September 23, 2021
 
-Fixed bug with foreign table SQL requesting data for multiple tables
+Fixed compile issue where LINQ dynamic core was not referenced correctly
 
 # 0.9.7
 September 22, 2021

--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,4 +1,4 @@
-# 0.9.9
+# 0.9.10
 September 23, 2021
 
 * Fixed bug with foreign table SQL requesting data for multiple tables

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.9.9</version>
+		<version>0.9.10</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -12,7 +12,7 @@
 		<description>Implements the Searchlight REST query language for CSharp.  The Searchlight language is database neutral and can support most database technologies.  Using Searchlight, you can provide a rich query language via your API, while still being completely safe from SQL injection attacks.  Searchlight enables you to use multiple database engines with the same functionality, and to transform queries using the in-memory abstract syntax tree prior to execution.</description>
 		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
 		<releaseNotes>
-			# 0.9.9
+			# 0.9.10
 			September 23, 2021
 
 			* Fixed bug with foreign table SQL requesting data for multiple tables
@@ -23,7 +23,9 @@
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-searchlight" />
 		<dependencies>
-			<group targetFramework="net5.0"/>
+			<group targetFramework="net5.0">
+				<dependency id="System.Linq.Dynamic.Core" version="1.2.12" />
+			</group>
 		</dependencies>
 	</metadata>
 	<files>

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.9.8</version>
+		<version>0.9.9</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -12,10 +12,12 @@
 		<description>Implements the Searchlight REST query language for CSharp.  The Searchlight language is database neutral and can support most database technologies.  Using Searchlight, you can provide a rich query language via your API, while still being completely safe from SQL injection attacks.  Searchlight enables you to use multiple database engines with the same functionality, and to transform queries using the in-memory abstract syntax tree prior to execution.</description>
 		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
 		<releaseNotes>
-			# 0.9.8
+			# 0.9.9
 			September 23, 2021
 
 			* Fixed bug with foreign table SQL requesting data for multiple tables
+			* Added tests to verify that multiple searchlight flags work as expected
+			* Fixed issue where a searchlight flag without aliases caused a crash
 		</releaseNotes>
 		<copyright>Copyright 2013 - 2021</copyright>
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>

--- a/src/Searchlight/Attributes/SearchlightFlag.cs
+++ b/src/Searchlight/Attributes/SearchlightFlag.cs
@@ -9,6 +9,7 @@ namespace Searchlight
     /// <summary>
     /// Represents a flag that you can set using the "$include" parameter
     /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public class SearchlightFlag : Attribute
     {
         /// <summary>

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -223,9 +223,12 @@ namespace Searchlight
             {
                 src.AddInclude(flag.Name, flag);
                 src._knownIncludes.Add(flag.Name);
-                foreach (var alias in flag.Aliases)
+                if (flag.Aliases != null)
                 {
-                    src.AddInclude(alias, flag);
+                    foreach (var alias in flag.Aliases)
+                    {
+                        src.AddInclude(alias, flag);
+                    }
                 }
             }
 

--- a/tests/Searchlight.Tests/FlagTests.cs
+++ b/tests/Searchlight.Tests/FlagTests.cs
@@ -12,6 +12,7 @@ namespace Searchlight.Tests
     {
         [SearchlightModel]
         [SearchlightFlag(Name = "TestFlag", Aliases = new string[] { "AliasOne", "AliasTwo" })]
+        [SearchlightFlag(Name = "TestTwo")]
         public class FlagTestClass
         {
         }
@@ -31,6 +32,8 @@ namespace Searchlight.Tests
             Assert.AreEqual(1, syntax.Flags.Count);
             Assert.AreEqual("TestFlag", syntax.Flags[0].Name);
             Assert.AreEqual(true, syntax.HasFlag("TestFlag"));
+            Assert.AreEqual(false, syntax.HasFlag("TestTwo"));
+            Assert.AreEqual(false, syntax.HasFlag("SomeFlagThatDoesntExist"));
 
             // Test whether the flag can be found by its alias
             syntax = engine.Parse(new FetchRequest()
@@ -49,6 +52,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(1, syntax.Flags.Count);
             Assert.AreEqual("TestFlag", syntax.Flags[0].Name);
             Assert.AreEqual(true, syntax.HasFlag("TestFlag"));
+            Assert.AreEqual(false, syntax.HasFlag("TestTwo"));
 
             // Test whether the flag is false by default
             syntax = engine.Parse(new FetchRequest()
@@ -57,6 +61,7 @@ namespace Searchlight.Tests
             });
             Assert.AreEqual(0, syntax.Flags.Count);
             Assert.AreEqual(false, syntax.HasFlag("TestFlag"));
+            Assert.AreEqual(false, syntax.HasFlag("TestTwo"));
 
             // Test whether an unknown flag throws the correct error
             var ex = Assert.ThrowsException<IncludeNotFound>(() =>
@@ -70,6 +75,16 @@ namespace Searchlight.Tests
             Assert.AreEqual("AnUnknownAlias", ex.IncludeName);
             Assert.AreEqual("TestFlag, AnUnknownAlias, AnotherUnknownAliasButThisOneDoesntGetTestedBecauseTheFirstOneFails", ex.OriginalInclude);
             Assert.IsTrue(ex.KnownIncludes.Contains("TestFlag"));
+            
+            // Check whether two flags can be specified
+            syntax = engine.Parse(new FetchRequest()
+            {
+                table = "FlagTestClass",
+                include = "TestFlag, TestTwo"
+            });
+            Assert.AreEqual(2, syntax.Flags.Count);
+            Assert.AreEqual(true, syntax.HasFlag("TestFlag"));
+            Assert.AreEqual(true, syntax.HasFlag("TestTwo"));
         }
     }
 }


### PR DESCRIPTION
Advanced version number to 0.9.9 since 0.9.8 didn't get committed correctly

Addresses #57 and tags #58 as being fixed in version 0.9.9