### PR TITLE
Enable maximum parameters to be configured at the engine level

### DIFF
--- a/src/Searchlight/Attributes/SearchlightModel.cs
+++ b/src/Searchlight/Attributes/SearchlightModel.cs
@@ -21,7 +21,7 @@ namespace Searchlight
         /// <summary>
         /// The maximum number of parameters that can be used when querying this model
         /// </summary>
-        public int MaximumParameters { get; set; }
+        public int? MaximumParameters { get; set; }
         
         /// <summary>
         /// The default sort criteria to use when none are specified

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -50,8 +50,9 @@ namespace Searchlight
 
         /// <summary>
         /// Some data sources can only handle a specified number of parameters.
+        /// If set at the data source level, this overrides the value set on the SearchlightEngine object.
         /// </summary>
-        public int MaximumParameters { get; set; }
+        public int? MaximumParameters { get; set; }
 
         private readonly List<string> _knownIncludes = new List<string>();
         private readonly Dictionary<string, object> _includeDict = new Dictionary<string, object>();

--- a/src/Searchlight/SearchlightEngine.cs
+++ b/src/Searchlight/SearchlightEngine.cs
@@ -20,6 +20,11 @@ namespace Searchlight
         /// Represents the maximum size of a single page
         /// </summary>
         public int? MaximumPageSize { get; set; }
+        
+        /// <summary>
+        /// Set the maximum complexity of Searchlight filters at the engine level
+        /// </summary>
+        public int? MaximumParameters { get; set; }
 
         /// <summary>
         /// Adds a new class to the engine

--- a/src/Searchlight/SqlExecutor.cs
+++ b/src/Searchlight/SqlExecutor.cs
@@ -21,9 +21,10 @@ namespace Searchlight
             sql.OrderByClause = RenderOrderByClause(query.OrderBy, sql);
 
             // Sanity tests
-            if (sql.Parameters.Count > query.Source.MaximumParameters && query.Source.MaximumParameters > 0)
+            var maxParams = query.Source.MaximumParameters ?? query.Source.Engine?.MaximumParameters ?? 0;
+            if (maxParams > 0 && sql.Parameters.Count > maxParams)
             {
-                throw new TooManyParameters() { MaximumParameterCount = query.Source.MaximumParameters, OriginalFilter = query.OriginalFilter };
+                throw new TooManyParameters() { MaximumParameterCount = maxParams, OriginalFilter = query.OriginalFilter };
             }
             var where = sql.WhereClause.Length > 0 ? $" WHERE {sql.WhereClause}" : "";
             var order = sql.OrderByClause.Length > 0 ? $" ORDER BY {sql.OrderByClause}" : "";

--- a/tests/Searchlight.Tests/SqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/SqlExecutorTests.cs
@@ -29,18 +29,30 @@ namespace Searchlight.Tests
         {
             string originalFilter =
                 "b in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256)";
-            var ex = Assert.ThrowsException<TooManyParameters>((Action) (() =>
+            var ex = Assert.ThrowsException<TooManyParameters>(() =>
             {
                 var query = _source.Parse(originalFilter);
-                var sql = query.ToSqlServerCommand(false);
-            }));
+                query.ToSqlServerCommand(false);
+            });
             Assert.AreEqual(originalFilter, ex.OriginalFilter);
 
             // Verify that 0 is treated as unlimited
             _source.MaximumParameters = 0;
             var syntax = _source.Parse(originalFilter);
             Assert.IsNotNull(syntax);
-            _source.MaximumParameters = 200;
+            _source.MaximumParameters = null;
+            
+            // Verify that we can also set maximum parameters at the engine level
+            _source.Engine = new SearchlightEngine
+            {
+                MaximumParameters = 50
+            };
+            ex = Assert.ThrowsException<TooManyParameters>(() =>
+            {
+                var query = _source.Parse(originalFilter);
+                query.ToSqlServerCommand(false);
+            });
+            Assert.AreEqual(originalFilter, ex.OriginalFilter);
         }
 
         [TestMethod]


### PR DESCRIPTION
It would be nice to set "maximum parameters for a query" at the engine level so that we can quickly set this value for everything.

Let's support that.