### PR TITLE
Added options at the engine level for SQL Server

### DIFF
--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -280,7 +280,7 @@ namespace Searchlight
 
         public SyntaxTree Parse(FetchRequest request)
         {
-            SyntaxTree query = new SyntaxTree
+            var query = new SyntaxTree
             {
                 Source = this,
                 OriginalFilter = request.filter,

--- a/src/Searchlight/SearchlightEngine.cs
+++ b/src/Searchlight/SearchlightEngine.cs
@@ -2,8 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Searchlight.Query;
+using System.Text;
 using Searchlight.Exceptions;
+using Searchlight.Query;
 
 namespace Searchlight
 {
@@ -32,6 +33,35 @@ namespace Searchlight
         public int? MaximumParameters { get; set; }
 
         /// <summary>
+        /// SQL Server: Use a single compound query that returns multiple result sets to avoid excess roundtrips.
+        /// </summary>
+        public bool useResultSet { get; set; } = true;
+
+        /// <summary>
+        /// SQL Server: Set this flag to true to specify `WITH (NOLOCK)` for all non-temporary tables.
+        /// Can potentially improve performance when true.  If you use Read Uncommitted, this flag has no
+        /// effect.
+        /// </summary>
+        public bool useNoLock { get; set; }
+
+        /// <summary>
+        /// SQL Server: If true, all searchlight queries begin with `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED`.
+        /// Can potentially improve performance when true.  Using this flag set to true can sometimes read
+        /// slightly inconsistent results.
+        ///
+        /// DEFAULT: True.
+        /// </summary>
+        public bool useReadUncommitted { get; set; } = true;
+
+        /// <summary>
+        /// SQL Server: If true, prefixes a query with `SET NOCOUNT ON`.  Can potentially improve performance 
+        /// when true.
+        ///
+        /// DEFAULT: True.
+        /// </summary>
+        public bool useNoCount { get; set; } = true;
+
+        /// <summary>
         /// Adds a new class to the engine
         /// </summary>
         /// <param name="type"></param>
@@ -48,6 +78,18 @@ namespace Searchlight
                     _dictionary.Add(alias, ds);
                 }
             }
+            return this;
+        }
+
+        /// <summary>
+        /// Add a hand-constructed data source
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public SearchlightEngine AddDataSource(DataSource source)
+        {
+            _dictionary.Add(source.TableName, source);
+            source.Engine = this;
             return this;
         }
 
@@ -106,6 +148,35 @@ namespace Searchlight
                 }
             }
             return this;
+        }
+        
+        /// <summary>
+        /// Produces the intro for a query, setting up any flags or options.
+        /// </summary>
+        /// <returns>The query</returns>
+        internal string DecorateIntro() 
+        {
+            var sb = new StringBuilder();
+            if (useNoCount) {
+                sb.Append("SET NOCOUNT ON;\n");
+            }
+            if (useReadUncommitted) {
+                sb.Append("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n");
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Produces a table name using all the provided options
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        internal string DecorateTableName(string tableName) 
+        {
+            if (useNoLock) {
+                return $"{tableName} WITH (nolock)";
+            }
+            return tableName;
         }
     }
 }

--- a/src/Searchlight/SqlExecutor.cs
+++ b/src/Searchlight/SqlExecutor.cs
@@ -13,9 +13,9 @@ namespace Searchlight
         /// Convert this syntax tree to a SQL Query Builder for this data source
         /// </summary>
         /// <param name="query">The query to convert to SQL text</param>
-        /// <param name="useMultiFetch">If true, will produce a multi result set query where the first result set is the total count of records for pagination purposes</param>
-        public static SqlQuery ToSqlServerCommand(this SyntaxTree query, bool useMultiFetch)
+        public static SqlQuery ToSqlServerCommand(this SyntaxTree query)
         {
+            var engine = query.Source.Engine ?? new SearchlightEngine();
             var sql = new SqlQuery {Syntax = query};
             sql.WhereClause = RenderJoinedClauses(query.Filter, sql);
             sql.OrderByClause = RenderOrderByClause(query.OrderBy);
@@ -43,7 +43,7 @@ namespace Searchlight
             }
             
             // If the user wants multi-fetch to retrieve row count
-            if (useMultiFetch)
+            if (engine.useResultSet)
             {
                 // If we're doing multi-fetch, we have to retrieve sorted/paginated records into a temp table before
                 // joining with any child collections
@@ -52,7 +52,8 @@ namespace Searchlight
                     var commandClauses = sql.ResultSetClauses.Count > 0
                         ? String.Join("\n", sql.ResultSetClauses) + "\n"
                         : "";
-                    sql.CommandText = $"SELECT COUNT(1) AS TotalRecords FROM {query.Source.TableName}{where};\n" +
+                    sql.CommandText = $"{engine.DecorateIntro()}" +
+                                      $"SELECT COUNT(1) AS TotalRecords FROM {query.Source.TableName}{where};\n" +
                                       $"SELECT * INTO #temp FROM {query.Source.TableName}{where}{order}{offset};\n" +
                                       $"SELECT * FROM #temp{order};\n" +
                                       commandClauses +
@@ -60,13 +61,15 @@ namespace Searchlight
                 }
                 else
                 {
-                    sql.CommandText = $"SELECT COUNT(1) AS TotalRecords FROM {query.Source.TableName}{where};\n" +
-                                      $"SELECT * FROM {query.Source.TableName}{where}{order}{offset};\n";
+                    sql.CommandText = $"{engine.DecorateIntro()}" +
+                                      $"SELECT COUNT(1) AS TotalRecords FROM {engine.DecorateTableName(query.Source.TableName)}{where};\n" +
+                                      $"SELECT * FROM {engine.DecorateTableName(query.Source.TableName)}{where}{order}{offset};\n";
                 }
             }
             else
             {
-                sql.CommandText = $"SELECT * FROM {query.Source.TableName}{where}{order}{offset}";
+                sql.CommandText = $"{engine.DecorateIntro()}" +
+                                  $"SELECT * FROM {engine.DecorateTableName(query.Source.TableName)}{where}{order}{offset}";
             }
             return sql;
         }
@@ -179,6 +182,7 @@ namespace Searchlight
             }
         }
     }
+
 
     /*
     /// <summary>

--- a/tests/Searchlight.Tests/ExceptionTests.cs
+++ b/tests/Searchlight.Tests/ExceptionTests.cs
@@ -30,7 +30,7 @@ namespace Searchlight.Tests
             var ex = Assert.ThrowsException<EmptyClause>((Action)(() =>
             {
                 var query = src.Parse(originalFilter);
-                var sql = query.ToSqlServerCommand(false);
+                var sql = query.ToSqlServerCommand();
             }));
             Assert.AreEqual(originalFilter, ex.OriginalFilter);
         }

--- a/tests/Searchlight.Tests/ForeignKeyTests.cs
+++ b/tests/Searchlight.Tests/ForeignKeyTests.cs
@@ -69,8 +69,10 @@ namespace Searchlight.Tests
             SyntaxTree syntax = engine.Parse(request);
 
             // Convert this into a multiple recordset SQL string
-            var query = syntax.ToSqlServerCommand(true);
-            Assert.AreEqual("SELECT COUNT(1) AS TotalRecords FROM LibraryBook WHERE Author LIKE @p1;\n" +
+            engine.useResultSet = true;
+            var query = syntax.ToSqlServerCommand();
+            Assert.AreEqual("SET NOCOUNT ON;\nSET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n" +
+                            "SELECT COUNT(1) AS TotalRecords FROM LibraryBook WHERE Author LIKE @p1;\n" +
                             "SELECT * INTO #temp FROM LibraryBook WHERE Author LIKE @p1 ORDER BY Name ASC OFFSET 20 ROWS FETCH NEXT 20 ROWS ONLY;\n" +
                             "SELECT * FROM #temp ORDER BY Name ASC;\n" +
                             "SELECT t1.* FROM BookReservation t1 INNER JOIN #temp ON t1.ISBN = #temp.ISBN;\n" +
@@ -98,8 +100,10 @@ namespace Searchlight.Tests
             SyntaxTree syntax = engine.Parse(request);
 
             // Convert this into a multiple recordset SQL string
-            var query = syntax.ToSqlServerCommand(true);
-            Assert.AreEqual("SELECT COUNT(1) AS TotalRecords FROM LibraryBook WHERE Author LIKE @p1;\n" +
+            engine.useResultSet = true;
+            var query = syntax.ToSqlServerCommand();
+            Assert.AreEqual("SET NOCOUNT ON;\nSET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;\n" +
+                            "SELECT COUNT(1) AS TotalRecords FROM LibraryBook WHERE Author LIKE @p1;\n" +
                             "SELECT * INTO #temp FROM LibraryBook WHERE Author LIKE @p1 ORDER BY Name ASC OFFSET 20 ROWS FETCH NEXT 20 ROWS ONLY;\n" +
                             "SELECT * FROM #temp ORDER BY Name ASC;\n" +
                             "SELECT t1.* FROM BookReservation t1 INNER JOIN #temp ON t1.ISBN = #temp.ISBN;\n" +


### PR DESCRIPTION
Searchlight will now suppot adjustments such as nolock, read uncommitted, and nocount.

By default:
* NOCOUNT ON
* READ UNCOMMITTED

Optionally, you can turn off these features at the engine level.