### PR TITLE
Added support for "NOW" as a constant in date queries

### DIFF
--- a/src/Searchlight/StringConstants.cs
+++ b/src/Searchlight/StringConstants.cs
@@ -126,6 +126,7 @@ namespace Searchlight
         /// </summary>
         public static readonly Dictionary<string, Func<DateTime>> DEFINED_DATES = new Dictionary<string, Func<DateTime>>
         {
+            {"NOW", () => DateTime.UtcNow},
             {"TODAY", () => DateTime.Today},
             {"TOMORROW", () => DateTime.Today.AddDays(1)},
             {"YESTERDAY", () => DateTime.Today.AddDays(-1)}

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -13,6 +13,7 @@ namespace Searchlight.Tests
     public class LinqExecutorTests
     {
         private readonly DataSource src;
+        private static List<EmployeeObj> list;
         
         [SearchlightModel(DefaultSort = nameof(name))]
         public class EmployeeObj
@@ -26,53 +27,72 @@ namespace Searchlight.Tests
 
         public static List<EmployeeObj> GetTestList()
         {
-            List<EmployeeObj> list = new List<EmployeeObj>
+            if (list == null)
             {
-                new EmployeeObj()
-                { hired = DateTime.Today, id = 1, name = "Alice Smith", onduty = true, paycheck = 1000.00m },
-                new EmployeeObj()
+                list = new List<EmployeeObj>
                 {
-                    hired = DateTime.Today.AddMonths(-1),
-                    id = 2,
-                    name = "Bob Rogers",
-                    onduty = true,
-                    paycheck = 1000.00m
-                },
-                new EmployeeObj()
-                {
-                    hired = DateTime.Today.AddMonths(-6),
-                    id = 3,
-                    name = "Charlie Prentiss",
-                    onduty = false,
-                    paycheck = 800.0m
-                },
-                new EmployeeObj()
-                {
-                    hired = DateTime.Today.AddMonths(-12),
-                    id = 4,
-                    name = "Danielle O'Shea",
-                    onduty = false,
-                    paycheck = 1200.0m
-                },
-                new EmployeeObj()
-                {
-                    hired = DateTime.Today.AddMonths(1),
-                    id = 5,
-                    name = "Ernest Nofzinger",
-                    onduty = true,
-                    paycheck = 1000.00m
-                },
-                new EmployeeObj()
-                { hired = DateTime.Today.AddMonths(4), id = 6, name = null, onduty = false, paycheck = 10.00m },
-                new EmployeeObj()
-                {
-                    hired = DateTime.Today.AddMonths(2),
-                    id = 7,
-                    name = "Roderick 'null' Sqlkeywordtest",
-                    onduty = false,
-                    paycheck = 578.00m
-                }
-            };
+                    new EmployeeObj()
+                        { hired = DateTime.Today, id = 1, name = "Alice Smith", onduty = true, paycheck = 1000.00m },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.Today.AddMonths(-1),
+                        id = 2,
+                        name = "Bob Rogers",
+                        onduty = true,
+                        paycheck = 1000.00m
+                    },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.Today.AddMonths(-6),
+                        id = 3,
+                        name = "Charlie Prentiss",
+                        onduty = false,
+                        paycheck = 800.0m
+                    },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.Today.AddMonths(-12),
+                        id = 4,
+                        name = "Danielle O'Shea",
+                        onduty = false,
+                        paycheck = 1200.0m
+                    },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.Today.AddMonths(1),
+                        id = 5,
+                        name = "Ernest Nofzinger",
+                        onduty = true,
+                        paycheck = 1000.00m
+                    },
+                    new EmployeeObj()
+                        { hired = DateTime.Today.AddMonths(4), id = 6, name = null, onduty = false, paycheck = 10.00m },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.Today.AddMonths(2),
+                        id = 7,
+                        name = "Roderick 'null' Sqlkeywordtest",
+                        onduty = false,
+                        paycheck = 578.00m
+                    },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.UtcNow.AddHours(-1),
+                        id = 8,
+                        name = "Joe 'Fresh Hire' McGillicuddy",
+                        onduty = false,
+                        paycheck = 123.00m,
+                    },
+                    new EmployeeObj()
+                    {
+                        hired = DateTime.UtcNow.AddHours(1),
+                        id = 8,
+                        name = "Carol 'Starting Soon!' Yamashita",
+                        onduty = false,
+                        paycheck = 987.00m,
+                    }
+                };
+            }
             return list;
         }
 
@@ -99,7 +119,7 @@ namespace Searchlight.Tests
 
             // Execute the query and ensure that each result matches
             var results = syntax.QueryCollection<EmployeeObj>(list);
-            Assert.AreEqual(5, results.records.Length);
+            Assert.AreEqual(7, results.records.Length);
             foreach (var e in results.records)
             {
                 Assert.IsTrue(e.id > 1);
@@ -134,11 +154,11 @@ namespace Searchlight.Tests
 
             // Execute the query and ensure that each result matches
             var results = syntax.QueryCollection<EmployeeObj>(list);
-            Assert.AreEqual(4, results.records.Length);
+            Assert.AreEqual(6, results.records.Length);
             foreach (var e in results.records)
             {
                 Assert.IsTrue(e.id > 1);
-                Assert.IsTrue(e.paycheck is 800.0m or 1200.0m or 10.0m or 578.00m);
+                Assert.IsTrue(e.paycheck is 800.0m or 1200.0m or 10.0m or 578.00m or 123.00m or 987.00m);
             }
         }
 
@@ -228,7 +248,7 @@ namespace Searchlight.Tests
             // Execute the query and ensure that each result matches
             var results = syntax.QueryCollection<EmployeeObj>(list);
             var resultsArr = results;
-            Assert.AreEqual(6, resultsArr.records.Length);
+            Assert.AreEqual(8, resultsArr.records.Length);
             foreach (var e in resultsArr.records)
             {
                 Assert.IsTrue(e.name.Contains("s", StringComparison.OrdinalIgnoreCase));
@@ -250,7 +270,7 @@ namespace Searchlight.Tests
             // Execute the query and ensure that each result matches
             var results = syntax.QueryCollection<EmployeeObj>(list);
             var resultsArr = results;
-            Assert.AreEqual(5, resultsArr.records.Length);
+            Assert.AreEqual(7, resultsArr.records.Length);
             foreach (var e in resultsArr.records)
             {
                 Assert.IsTrue(string.Compare(e.name, "b", StringComparison.CurrentCultureIgnoreCase) > 0);
@@ -272,7 +292,7 @@ namespace Searchlight.Tests
             // Execute the query and ensure that each result matches
             var results = syntax.QueryCollection<EmployeeObj>(list);
             var resultsArr = results;
-            Assert.AreEqual(5, resultsArr.records.Length);
+            Assert.AreEqual(7, resultsArr.records.Length);
             foreach (var e in resultsArr.records)
             {
                 Assert.IsTrue(string.Compare(e.name.Substring(0, "bob rogers".Length), "bob rogers", StringComparison.CurrentCultureIgnoreCase) >= 0);
@@ -470,27 +490,27 @@ namespace Searchlight.Tests
             var syntax = src.Parse("hired < TODAY");
 
             var result = syntax.QueryCollection(list);
-            
-            Assert.IsTrue(result.records.Any());
-            Assert.IsTrue(result.records.Length == 3);
+            Assert.AreEqual(3, result.records.Length);
 
             syntax = src.Parse("hired < TOMORROW");
             result = syntax.QueryCollection(list);
-            
-            Assert.IsTrue(result.records.Any());
-            Assert.IsTrue(result.records.Length == 4);
+            Assert.AreEqual(6, result.records.Length);
             
             syntax = src.Parse("hired < tomorrow");
             result = syntax.QueryCollection(list);
-            
-            Assert.IsTrue(result.records.Any());
-            Assert.IsTrue(result.records.Length == 4);
+            Assert.AreEqual(6, result.records.Length);
             
             syntax = src.Parse("hired > YESTERDAY");
             result = syntax.QueryCollection(list);
+            Assert.AreEqual(6, result.records.Length);
+
+            syntax = src.Parse("hired > NOW");
+            result = syntax.QueryCollection(list);
+            Assert.AreEqual(4, result.records.Length);
             
-            Assert.IsTrue(result.records.Any());
-            Assert.IsTrue(result.records.Length == 4);
+            syntax = src.Parse("hired < NOW");
+            result = syntax.QueryCollection(list);
+            Assert.AreEqual(5, result.records.Length);
             
             Assert.ThrowsException<FieldTypeMismatch>(() => src.Parse("hired > yesteryear"));
         }


### PR DESCRIPTION
It may be convenient when writing Searchlight queries to use shorthand such as TODAY, YESTERDAY, or NOW.  Let's enable NOW to address #89 