### PR TITLE
Compatibility with NetStandard 2.0 and later

### DIFF
--- a/src/Searchlight.MongoDB/MongoDbExecutor.cs
+++ b/src/Searchlight.MongoDB/MongoDbExecutor.cs
@@ -57,21 +57,31 @@ namespace MongoPetSitters
                 switch (clause)
                 {
                     case CriteriaClause criteria:
-                        return criteria.Operation switch
+                        switch (criteria.Operation)
                         {
-                            OperationType.Equals => Builders<T>.Filter.Eq(criteria.Column.FieldName, criteria.Value),
-                            OperationType.NotEqual => Builders<T>.Filter.Ne(criteria.Column.FieldName, criteria.Value),
-                            OperationType.GreaterThan => Builders<T>.Filter.Gt(criteria.Column.FieldName, criteria.Value),
-                            OperationType.GreaterThanOrEqual => Builders<T>.Filter.Gte(criteria.Column.FieldName, criteria.Value),
-                            OperationType.LessThan => Builders<T>.Filter.Lt(criteria.Column.FieldName, criteria.Value),
-                            OperationType.LessThanOrEqual => Builders<T>.Filter.Lte(criteria.Column.FieldName, criteria.Value),
-                            OperationType.Contains => Builders<T>.Filter.Regex(criteria.Column.FieldName,
-new BsonRegularExpression("/" + criteria.Value + "/")),
-                            OperationType.StartsWith => Builders<T>.Filter.Regex(criteria.Column.FieldName,
-new BsonRegularExpression("/^" + criteria.Value + "/")),
-                            OperationType.EndsWith => Builders<T>.Filter.Regex(criteria.Column.FieldName,
-new BsonRegularExpression("/" + criteria.Value + "$/")),
-                            _ => throw new NotImplementedException(),
+                            case OperationType.Equals:
+                                return Builders<T>.Filter.Eq(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.NotEqual:
+                                return Builders<T>.Filter.Ne(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.GreaterThan:
+                                return Builders<T>.Filter.Gt(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.GreaterThanOrEqual:
+                                return Builders<T>.Filter.Gte(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.LessThan:
+                                return Builders<T>.Filter.Lt(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.LessThanOrEqual:
+                                return Builders<T>.Filter.Lte(criteria.Column.FieldName, criteria.Value);
+                            case OperationType.Contains:
+                                return Builders<T>.Filter.Regex(criteria.Column.FieldName,
+                                    new BsonRegularExpression("/" + criteria.Value + "/"));
+                            case OperationType.StartsWith:
+                                return Builders<T>.Filter.Regex(criteria.Column.FieldName,
+                                    new BsonRegularExpression("/^" + criteria.Value + "/"));
+                            case OperationType.EndsWith:
+                                return Builders<T>.Filter.Regex(criteria.Column.FieldName,
+                                    new BsonRegularExpression("/" + criteria.Value + "$/"));
+                            default:
+                                throw new NotImplementedException();
                         };
                     case InClause inClause:
                         return Builders<T>.Filter.In(inClause.Column.FieldName, inClause.Values);
@@ -87,12 +97,15 @@ new BsonRegularExpression("/" + criteria.Value + "$/")),
 
                     case CompoundClause compoundClause:
                         var innerFilters = BuildMongoFilter<T>(compoundClause.Children);
-                        return compoundClause.Conjunction switch
+                        switch (compoundClause.Conjunction)
                         {
-                            ConjunctionType.OR => Builders<T>.Filter.Or(innerFilters),
-                            ConjunctionType.AND => Builders<T>.Filter.And(innerFilters),
-                            _ => throw new NotImplementedException(),
-                        };
+                            case ConjunctionType.OR:
+                                return Builders<T>.Filter.Or(innerFilters);
+                            case ConjunctionType.AND:
+                                return Builders<T>.Filter.And(innerFilters);
+                            default:
+                                throw new NotImplementedException();
+                        }
                     default:
                         throw new NotImplementedException();
                 }

--- a/src/Searchlight.MongoDB/Searchlight.MongoDB.csproj
+++ b/src/Searchlight.MongoDB/Searchlight.MongoDB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Searchlight/Attributes/SearchlightModel.cs
+++ b/src/Searchlight/Attributes/SearchlightModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace Searchlight
 {

--- a/src/Searchlight/Caching/ItemFetchCache.cs
+++ b/src/Searchlight/Caching/ItemFetchCache.cs
@@ -14,12 +14,13 @@ namespace Searchlight.Caching
         /// <summary>
         /// Concurrent dictionary for fetching items
         /// </summary>
-        private readonly ConcurrentDictionary<KEY, ItemCache<ITEM>> _item_dict = new();
+        private readonly ConcurrentDictionary<KEY, ItemCache<ITEM>> _item_dict =
+            new ConcurrentDictionary<KEY, ItemCache<ITEM>>();
 
         /// <summary>
         /// Default time frame is that items expire after an hour
         /// </summary>
-        protected TimeSpan _cacheDuration = new(1, 0, 0);
+        protected TimeSpan _cacheDuration = new TimeSpan(1, 0, 0);
 
 
         #region Constructor
@@ -123,7 +124,7 @@ namespace Searchlight.Caching
         /// <param name="item_loaded_timestamp"></param>
         protected void Set(KEY key, ITEM item, DateTime item_loaded_timestamp)
         {
-            ItemCache<ITEM> cache = new()
+            var cache = new ItemCache<ITEM>()
             {
                 CachedObject = item,
                 CacheDate = item_loaded_timestamp

--- a/src/Searchlight/Caching/ObjectCache.cs
+++ b/src/Searchlight/Caching/ObjectCache.cs
@@ -6,12 +6,12 @@ namespace Searchlight.Caching
     {
         private ITEM _item;
         private DateTime _next_cache_time;
-        private readonly object _cache_lock = new();
+        private readonly object _cache_lock = new object();
 
         /// <summary>
         /// Length of time to keep this cache before triggering a re-fetch
         /// </summary>
-        protected TimeSpan _cacheDuration = new(2, 0, 0);
+        protected TimeSpan _cacheDuration = new TimeSpan(2, 0, 0);
 
         #region Constructor
         public ObjectCache()

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -317,27 +317,32 @@ namespace Searchlight
             var flags = new List<SearchlightFlag>();
             if (!string.IsNullOrWhiteSpace(includes))
             {
-                foreach (var name in includes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                foreach (var n in includes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    var upperName = name.Trim()?.ToUpperInvariant();
-                    if (_includeDict.TryGetValue(upperName, out var obj))
+                    var name = n.Trim();
+                    if (name != null)
                     {
-                        if (obj is ICommand command)
+                        var upperName = name.Trim()?.ToUpperInvariant();
+                        if (_includeDict.TryGetValue(upperName, out var obj))
                         {
-                            list.Add(command);
+                            if (obj is ICommand command)
+                            {
+                                list.Add(command);
+                            }
+                            else if (obj is SearchlightFlag flag)
+                            {
+                                flags.Add(flag);
+                            }
                         }
-                        else if (obj is SearchlightFlag flag)
+                        else
                         {
-                            flags.Add(flag);
+                            throw new IncludeNotFound()
+                            {
+                                OriginalInclude = includes,
+                                IncludeName = name,
+                                KnownIncludes = _knownIncludes.ToArray()
+                            };
                         }
-                    }
-                    else
-                    {
-                        throw new IncludeNotFound() { 
-                            OriginalInclude = includes, 
-                            IncludeName = name, 
-                            KnownIncludes = _knownIncludes.ToArray() 
-                        };
                     }
                 }
             }

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -212,7 +212,7 @@ namespace Searchlight
             }
             
             // default sort cannot be null and must be a valid column
-            if (src.DefaultSort is not null)
+            if (src.DefaultSort != null)
             {
                 try
                 {
@@ -317,9 +317,9 @@ namespace Searchlight
             var flags = new List<SearchlightFlag>();
             if (!string.IsNullOrWhiteSpace(includes))
             {
-                foreach (var name in includes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                foreach (var name in includes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    var upperName = name.ToUpperInvariant();
+                    var upperName = name.Trim()?.ToUpperInvariant();
                     if (_includeDict.TryGetValue(upperName, out var obj))
                     {
                         if (obj is ICommand command)
@@ -667,7 +667,7 @@ namespace Searchlight
         private static object DefinedDateOperators(string valueToken)
         {
             StringConstants.DEFINED_DATES.TryGetValue(valueToken.ToUpper(), out var result);
-            return (result != null) ? result.Invoke() : valueToken;
+            return (result != null) ? (object)result.Invoke() : valueToken;
         }
 
         /// <summary>

--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -51,14 +51,17 @@ namespace Searchlight
             var totalCount = filteredAndSorted.Count;
             
             // If the user requested pagination
-            var paginated = (tree.PageNumber, tree.PageSize) switch
+            IEnumerable<T> paginated = filteredAndSorted;
+            if (tree.PageNumber > 0 && tree.PageSize > 0)
             {
                 // case 1: user specified page number and page size
-                (> 0, > 0) => filteredAndSorted.Skip((int)(tree.PageSize * tree.PageNumber)).Take((int)tree.PageSize),
+                paginated = filteredAndSorted.Skip((int)(tree.PageSize * tree.PageNumber)).Take((int)tree.PageSize);
+            }
+            else if (tree.PageNumber == 0 && tree.PageSize > 0)
+            {
                 // case 2: user specified a page size but no page number
-                (0, > 0) => filteredAndSorted.Take((int)tree.PageSize),
-                _ => filteredAndSorted
-            };
+                paginated = filteredAndSorted.Take((int)tree.PageSize);
+            }
 
             // construct the return fetch result
             var result = new FetchResult<T>

--- a/src/Searchlight/Nesting/ICommand.cs
+++ b/src/Searchlight/Nesting/ICommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Searchlight.Nesting
+﻿using System.Collections.Generic;
+
+namespace Searchlight.Nesting
 {
     public interface ICommand
     {
@@ -6,18 +8,18 @@
         /// If there is an SQL component to this command, apply it here
         /// </summary>
         /// <param name="sql"></param>
-        public void Apply(SqlQuery sql);
+        void Apply(SqlQuery sql);
 
         /// <summary>
         /// The official name by which this command is known
         /// </summary>
         /// <returns></returns>
-        public string GetName();
+        string GetName();
 
         /// <summary>
         /// List all names by which this command is known
         /// </summary>
         /// <returns></returns>
-        public string[] GetAliases();
+        string[] GetAliases();
     }
 }

--- a/src/Searchlight/Parsing/Tokenizer.cs
+++ b/src/Searchlight/Parsing/Tokenizer.cs
@@ -46,24 +46,22 @@ namespace Searchlight.Parsing
                     }
 
                     // If the token is actually part of a >= or <= block, add the equal sign to it.
-                    char? c2 = (i + 1 < line.Length) ? line[i + 1] : null;
-                    switch (c, c2)
+                    var c2 = (i + 1 < line.Length) ? (char?)line[i + 1] : null;
+                    if ((c == '!' && c2 == '=') ||
+                        (c == '<' && c2 == '>') ||
+                        (c == '<' && c2 == '=') ||
+                        (c == '>' && c2 == '='))
                     {
-                        case ('!', '='):
-                        case ('<', '>'):
-                        case ('<', '='):
-                        case ('>', '='):
-                            tokens.Enqueue(line.Substring(i, 2));
-                            i++;
-                            break;
-                        case ('<', _):
-                        case ('>', _):
-                            tokens.Enqueue(c.ToString());
-                            break;
+                        tokens.Enqueue(line.Substring(i, 2));
+                        i++;
+                    } else if (c == '<' || c == '>')
+                    {
+                        tokens.Enqueue(c.ToString());
+                    }
+                    else
+                    {
                         // This probably means it's a syntax error, but let's let the parser figure that out
-                        default:
-                            tokens.Enqueue(c.ToString());
-                            break;
+                        tokens.Enqueue(c.ToString());
                     }
 
                     sb.Length = 0;

--- a/src/Searchlight/Searchlight.csproj
+++ b/src/Searchlight/Searchlight.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Searchlight/SearchlightEngine.cs
+++ b/src/Searchlight/SearchlightEngine.cs
@@ -102,10 +102,16 @@ namespace Searchlight
         public SyntaxTree Parse(FetchRequest request)
         {
             var source = FindTable(request.table);
-            request.pageSize ??= DefaultPageSize;
+            if (request.pageSize == null)
+            {
+                request.pageSize = DefaultPageSize;
+            }
             if (MaximumPageSize != null)
             {
-                request.pageSize ??= MaximumPageSize;
+                if (request.pageSize == null)
+                {
+                    request.pageSize = MaximumPageSize;
+                }
                 if (request.pageSize > MaximumPageSize)
                 {
                     throw new InvalidPageSize { PageSize = $"larger than the allowed maximum pageSize, {MaximumPageSize}"};

--- a/src/Searchlight/SqlExecutor.cs
+++ b/src/Searchlight/SqlExecutor.cs
@@ -152,19 +152,19 @@ namespace Searchlight
                         case OperationType.NotEqual:
                             return $"{cc.Column.OriginalName} <> {sql.AddParameter(cc.Value)}";
                         case OperationType.Contains:
-                            if (cc.Value is not string)
+                            if (cc.Value?.GetType() != typeof(string))
                             {
                                 throw new Exception("Value was not a string type");
                             }
                             return $"{cc.Column.OriginalName} LIKE {sql.AddParameter("%" + cc.Value + "%")}";
                         case OperationType.StartsWith:
-                            if (cc.Value is not string)
+                            if (cc.Value?.GetType() != typeof(string))
                             {
                                 throw new Exception("Value was not a string type");
                             }
                             return $"{cc.Column.OriginalName} LIKE {sql.AddParameter(cc.Value + "%")}";
                         case OperationType.EndsWith:
-                            if (cc.Value is not string)
+                            if (cc.Value?.GetType() != typeof(string))
                             {
                                 throw new Exception("Value was not a string type");
                             }

--- a/tests/Searchlight.Tests/DataSourceTests.cs
+++ b/tests/Searchlight.Tests/DataSourceTests.cs
@@ -108,7 +108,7 @@ namespace Searchlight.Tests
             // Silly example
             Assert.ThrowsException<FieldNotFound>(() =>
             {
-                var clauses = _source.ParseFilter("AND ( ) OR ");
+                var parsedClause = _source.ParseFilter("AND ( ) OR ");
             });
 
             // Realistic example of a forgetful customer

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -158,7 +158,8 @@ namespace Searchlight.Tests
             foreach (var e in results.records)
             {
                 Assert.IsTrue(e.id > 1);
-                Assert.IsTrue(e.paycheck is 800.0m or 1200.0m or 10.0m or 578.00m or 123.00m or 987.00m);
+                Assert.IsTrue(e.paycheck == 800.0m || e.paycheck == 1200.0m || e.paycheck == 10.0m ||
+                              e.paycheck == 578.00m || e.paycheck == 123.00m || e.paycheck == 987.00m);
             }
         }
 
@@ -251,7 +252,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(8, resultsArr.records.Length);
             foreach (var e in resultsArr.records)
             {
-                Assert.IsTrue(e.name.Contains("s", StringComparison.OrdinalIgnoreCase));
+                Assert.IsTrue(e.name.IndexOf("s", StringComparison.OrdinalIgnoreCase) >= 0);
             }
         }
         
@@ -490,19 +491,19 @@ namespace Searchlight.Tests
             var syntax = src.Parse("hired < TODAY");
 
             var result = syntax.QueryCollection(list);
-            Assert.IsTrue(result.records.Length is 3 or 4);
+            Assert.IsTrue(result.records.Length == 3 || result.records.Length == 4);
 
             syntax = src.Parse("hired < TOMORROW");
             result = syntax.QueryCollection(list);
-            Assert.IsTrue(result.records.Length is 5 or 6);
+            Assert.IsTrue(result.records.Length == 5 || result.records.Length == 6);
             
             syntax = src.Parse("hired < tomorrow");
             result = syntax.QueryCollection(list);
-            Assert.IsTrue(result.records.Length is 5 or 6);
+            Assert.IsTrue(result.records.Length == 5 || result.records.Length == 6);
             
             syntax = src.Parse("hired > YESTERDAY");
             result = syntax.QueryCollection(list);
-            Assert.IsTrue(result.records.Length is 5 or 6);
+            Assert.IsTrue(result.records.Length == 5 || result.records.Length == 6);
 
             syntax = src.Parse("hired > NOW");
             result = syntax.QueryCollection(list);

--- a/tests/Searchlight.Tests/Searchlight.Tests.csproj
+++ b/tests/Searchlight.Tests/Searchlight.Tests.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Let's update Searchlight to include compatibility back to NetStandard 2.0 and NetCoreApp 3.1.  This enables Searchlight to work in a wider variety of projects.

Changes included:
* Undid some syntactic sugar "matching" patterns in the code; returned these to be just regular if/else statements.
* Updated some test suites to use fewer version-specific features.
* Addressed some type inference issues