### PR TITLE
Improve error handling for LINQ executor type mismatches

### DIFF
--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -77,7 +77,7 @@ namespace Searchlight
         private static IQueryable<T> InternalOrderBy<T>(IQueryable source, List<SortInfo> orderBy)
         {
             var queryExpr = source.Expression;
-            int count = 0;
+            var count = 0;
             ParameterExpression[] parameterExpressions =
             {
                 Expression.Parameter(source.ElementType, "Param_0")
@@ -117,19 +117,13 @@ namespace Searchlight
             foreach (var clause in query)
             {
                 var clauseExpression = BuildOneExpression(select, clause, src);
-
-                // First clause starts a run
                 if (result == null)
                 {
                     result = clauseExpression;
-
-                    // If the previous clause specified 'and'
                 }
                 else if (ct == ConjunctionType.AND)
                 {
                     result = Expression.And(result, clauseExpression);
-
-                    // If the previous clause specified 'or'
                 }
                 else if (ct == ConjunctionType.OR)
                 {
@@ -138,8 +132,6 @@ namespace Searchlight
 
                 ct = clause.Conjunction;
             }
-
-            // Here's your expression
             return result;
         }
 

--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Searchlight.Parsing;
 using Searchlight.Query;
 
 namespace Searchlight
@@ -27,7 +28,7 @@ namespace Searchlight
             
             // If the user specified a filter 
             var select = Expression.Parameter(typeof(T), "obj");
-            var expression = BuildExpression(select, tree.Filter, tree.Source);
+            var expression = BuildExpression<T>(select, tree.Filter, tree.Source);
             if (expression != null)
             {
                 var whereCallExpression = Expression.Call(
@@ -42,7 +43,7 @@ namespace Searchlight
             // If the user specified a sorting clause
             if (tree.OrderBy.Any())
             {
-                queryable = InternalOrderBy<T>(queryable, tree.OrderBy);
+                queryable = InternalOrderBy<T>(queryable, tree.Source, tree.OrderBy);
             }
 
             // Compute the list once and keep track of full length
@@ -74,7 +75,7 @@ namespace Searchlight
             return result;
         }
         
-        private static IQueryable<T> InternalOrderBy<T>(IQueryable source, List<SortInfo> orderBy)
+        private static IQueryable<T> InternalOrderBy<T>(IQueryable source, DataSource src, List<SortInfo> orderBy)
         {
             var queryExpr = source.Expression;
             var count = 0;
@@ -84,6 +85,7 @@ namespace Searchlight
             };
             foreach (var sort in orderBy)
             {
+                AssertClassHasProperty(typeof(T), src, sort.Column);
                 var methodName = count == 0 ? "OrderBy" : "ThenBy";
                 if (sort.Direction == SortDirection.Descending)
                 {
@@ -110,13 +112,13 @@ namespace Searchlight
         /// <param name="query"></param>
         /// <param name="src"></param>
         /// <returns></returns>
-        private static Expression BuildExpression(ParameterExpression select, List<BaseClause> query, DataSource src)
+        private static Expression BuildExpression<T>(ParameterExpression select, List<BaseClause> query, DataSource src)
         {
             var ct = ConjunctionType.NONE;
             Expression result = null;
             foreach (var clause in query)
             {
-                var clauseExpression = BuildOneExpression(select, clause, src);
+                var clauseExpression = BuildOneExpression<T>(select, clause, src);
                 if (result == null)
                 {
                     result = clauseExpression;
@@ -142,18 +144,23 @@ namespace Searchlight
         /// <param name="clause"></param>
         /// <param name="src"></param>
         /// <returns></returns>
-        private static Expression BuildOneExpression(ParameterExpression select, BaseClause clause, DataSource src)
+        private static Expression BuildOneExpression<T>(ParameterExpression select, BaseClause clause, DataSource src)
         {
             Expression field;
             Expression value;
             Expression result;
 
+            var t = typeof(T);
+
             switch (clause)
             {
                 case CriteriaClause criteria:
-                    // Obtain a parameter from this object
+                    AssertClassHasProperty(t, src, criteria.Column);
+                    
+                    // Set up LINQ expressions for this object
+                    var valueType = criteria.Column.FieldType;
                     field = Expression.Property(select, criteria.Column.FieldName);
-                    value = Expression.Constant(criteria.Value, criteria.Column.FieldType);
+                    value = Expression.Constant(criteria.Value, valueType);
                     switch (criteria.Operation)
                     {
                         case OperationType.Equals:
@@ -298,7 +305,7 @@ namespace Searchlight
                     break;
 
                 case CompoundClause compoundClause:
-                    result = BuildExpression(select, compoundClause.Children, src);
+                    result = BuildExpression<T>(select, compoundClause.Children, src);
                     break;
 
                 case InClause inClause:
@@ -320,6 +327,42 @@ namespace Searchlight
 
             // Negate the final expression if specified
             return clause.Negated ? Expression.Not(result) : result;
+        }
+
+        /// <summary>
+        /// Test this class to make sure it has the specified type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="source"></param>
+        /// <param name="column"></param>
+        /// <exception cref="FieldTypeMismatch"></exception>
+        /// <exception cref="FieldNotFound"></exception>
+        private static void AssertClassHasProperty(Type type, DataSource source, ColumnInfo column)
+        {
+            // If the types match, we've already verified it during engine definition
+            if (source.ModelType == type) return;
+            
+            // If the types don't match, we need to verify at runtime or throw a clear exception
+            var propInfo = type.GetProperty(column.FieldName);
+            if (propInfo != null)
+            {
+                if (propInfo.PropertyType != column.FieldType)
+                {
+                    throw new FieldTypeMismatch()
+                    {
+                        FieldName = $"{column.FieldName} on type {type.Name}",
+                        FieldType = propInfo.PropertyType.ToString(),
+                    };
+                }
+            }
+            else
+            {
+                throw new FieldNotFound()
+                {
+                    FieldName = column.FieldName,
+                    KnownFields = (from p in type.GetProperties() select p.Name).ToArray()
+                };
+            }
         }
     }
 }

--- a/src/Searchlight/Query/BetweenClause.cs
+++ b/src/Searchlight/Query/BetweenClause.cs
@@ -25,5 +25,13 @@ namespace Searchlight.Query
         /// Upper value in the between test
         /// </summary>
         public object UpperValue { get; set; }
+        
+        /// <summary>
+        /// Render this criteria in a readable string
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{Column.FieldName} between {LowerValue} and {UpperValue}";
+        }
     }
 }

--- a/src/Searchlight/Query/CompoundClause.cs
+++ b/src/Searchlight/Query/CompoundClause.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Searchlight.Query
@@ -14,5 +15,27 @@ namespace Searchlight.Query
         /// The children of this compound clause
         /// </summary>
         public List<BaseClause> Children { get; set; }
+
+        /// <summary>
+        /// Render this criteria in a readable string
+        /// </summary>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("(");
+            var numChildren = Children?.Count ?? 0;
+            for (var i = 0; i < numChildren; i++)
+            {
+                sb.Append(Children[i]);
+                if (i < numChildren)
+                {
+                    sb.Append(" ");
+                    sb.Append(Children[i].Conjunction);
+                    sb.Append(" ");
+                }
+            }
+            sb.Append(")");
+            return sb.ToString();
+        }
     }
 }

--- a/src/Searchlight/Query/CriteriaClause.cs
+++ b/src/Searchlight/Query/CriteriaClause.cs
@@ -25,5 +25,13 @@ namespace Searchlight.Query
         /// Value to test against
         /// </summary>
         public object Value { get; set; }
+
+        /// <summary>
+        /// Render this criteria in a readable string
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{Column.FieldName} {Operation} {Value}";
+        }
     }
 }

--- a/src/Searchlight/Query/InClause.cs
+++ b/src/Searchlight/Query/InClause.cs
@@ -20,5 +20,13 @@ namespace Searchlight.Query
         /// The list of values to test against
         /// </summary>
         public List<object> Values { get; set; }
+        
+        /// <summary>
+        /// Render this criteria in a readable string
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{Column.FieldName} in ({string.Join(", ", Values)})";
+        }
     }
 }

--- a/src/Searchlight/Query/IsNullClause.cs
+++ b/src/Searchlight/Query/IsNullClause.cs
@@ -15,5 +15,13 @@ namespace Searchlight.Query
         /// The field being tested
         /// </summary>
         public ColumnInfo Column { get; set; }
+        
+        /// <summary>
+        /// Render this criteria in a readable string
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{Column.FieldName} is {(this.Negated ? "not" : "")} null";
+        }
     }
 }

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -1,11 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Searchlight;
-using Searchlight.Parsing;
 using Searchlight.Query;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Searchlight.Exceptions;
+
+// This file has lots of intentional misspellings
+// ReSharper disable StringLiteralTypo
+// ReSharper disable CommentTypo
+
+// Highlighting allocations on this file is annoying 
+// ReSharper disable HeapView.DelegateAllocation
 
 namespace Searchlight.Tests
 {
@@ -16,6 +20,7 @@ namespace Searchlight.Tests
         private static List<EmployeeObj> _list;
         
         [SearchlightModel(DefaultSort = nameof(name))]
+        // ReSharper disable once MemberCanBePrivate.Global
         public class EmployeeObj
         {
             public string name { get; set; }
@@ -25,75 +30,71 @@ namespace Searchlight.Tests
             public bool onduty { get; set; }
         }
 
-        public static List<EmployeeObj> GetTestList()
+        private static List<EmployeeObj> GetTestList()
         {
-            if (_list == null)
+            return _list ??= new List<EmployeeObj>
             {
-                _list = new List<EmployeeObj>
+                new()
+                    { hired = DateTime.Today, id = 1, name = "Alice Smith", onduty = true, paycheck = 1000.00m },
+                new()
                 {
-                    new EmployeeObj()
-                        { hired = DateTime.Today, id = 1, name = "Alice Smith", onduty = true, paycheck = 1000.00m },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.Today.AddMonths(-1),
-                        id = 2,
-                        name = "Bob Rogers",
-                        onduty = true,
-                        paycheck = 1000.00m
-                    },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.Today.AddMonths(-6),
-                        id = 3,
-                        name = "Charlie Prentiss",
-                        onduty = false,
-                        paycheck = 800.0m
-                    },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.Today.AddMonths(-12),
-                        id = 4,
-                        name = "Danielle O'Shea",
-                        onduty = false,
-                        paycheck = 1200.0m
-                    },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.Today.AddMonths(1),
-                        id = 5,
-                        name = "Ernest Nofzinger",
-                        onduty = true,
-                        paycheck = 1000.00m
-                    },
-                    new EmployeeObj()
-                        { hired = DateTime.Today.AddMonths(4), id = 6, name = null, onduty = false, paycheck = 10.00m },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.Today.AddMonths(2),
-                        id = 7,
-                        name = "Roderick 'null' Sqlkeywordtest",
-                        onduty = false,
-                        paycheck = 578.00m
-                    },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.UtcNow.AddHours(-1),
-                        id = 8,
-                        name = "Joe 'Fresh Hire' McGillicuddy",
-                        onduty = false,
-                        paycheck = 123.00m,
-                    },
-                    new EmployeeObj()
-                    {
-                        hired = DateTime.UtcNow.AddHours(1),
-                        id = 8,
-                        name = "Carol 'Starting Soon!' Yamashita",
-                        onduty = false,
-                        paycheck = 987.00m,
-                    }
-                };
-            }
-            return _list;
+                    hired = DateTime.Today.AddMonths(-1),
+                    id = 2,
+                    name = "Bob Rogers",
+                    onduty = true,
+                    paycheck = 1000.00m
+                },
+                new()
+                {
+                    hired = DateTime.Today.AddMonths(-6),
+                    id = 3,
+                    name = "Charlie Prentiss",
+                    onduty = false,
+                    paycheck = 800.0m
+                },
+                new()
+                {
+                    hired = DateTime.Today.AddMonths(-12),
+                    id = 4,
+                    name = "Danielle O'Shea",
+                    onduty = false,
+                    paycheck = 1200.0m
+                },
+                new()
+                {
+                    hired = DateTime.Today.AddMonths(1),
+                    id = 5,
+                    name = "Ernest Nofzinger",
+                    onduty = true,
+                    paycheck = 1000.00m
+                },
+                new()
+                    { hired = DateTime.Today.AddMonths(4), id = 6, name = null, onduty = false, paycheck = 10.00m },
+                new()
+                {
+                    hired = DateTime.Today.AddMonths(2),
+                    id = 7,
+                    name = "Roderick 'null' Sqlkeywordtest",
+                    onduty = false,
+                    paycheck = 578.00m
+                },
+                new()
+                {
+                    hired = DateTime.UtcNow.AddHours(-1),
+                    id = 8,
+                    name = "Joe 'Fresh Hire' McGillicuddy",
+                    onduty = false,
+                    paycheck = 123.00m,
+                },
+                new()
+                {
+                    hired = DateTime.UtcNow.AddHours(1),
+                    id = 8,
+                    name = "Carol 'Starting Soon!' Yamashita",
+                    onduty = false,
+                    paycheck = 987.00m,
+                }
+            };
         }
 
         public LinqExecutorTests()
@@ -118,7 +119,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(1000.0m, ((CriteriaClause) syntax.Filter[1]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
+            var results = syntax.QueryCollection(list);
             Assert.AreEqual(7, results.records.Length);
             foreach (var e in results.records)
             {
@@ -153,13 +154,12 @@ namespace Searchlight.Tests
             Assert.AreEqual(1000.0m, ((CriteriaClause) cc.Children[1]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
+            var results = syntax.QueryCollection(list);
             Assert.AreEqual(6, results.records.Length);
             foreach (var e in results.records)
             {
                 Assert.IsTrue(e.id > 1);
-                Assert.IsTrue(e.paycheck == 800.0m || e.paycheck == 1200.0m || e.paycheck == 10.0m ||
-                              e.paycheck == 578.00m || e.paycheck == 123.00m || e.paycheck == 987.00m);
+                Assert.IsTrue(e.paycheck is 800.0m or 1200.0m or 10.0m or 578.00m or 123.00m or 987.00m);
             }
         }
 
@@ -178,7 +178,7 @@ namespace Searchlight.Tests
             Assert.AreEqual(4, ((BetweenClause) syntax.Filter[0]).UpperValue);
             
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
+            var results = syntax.QueryCollection(list);
             Assert.AreEqual(3, results.records.Length);
             foreach (var e in results.records)
             {
@@ -194,11 +194,11 @@ namespace Searchlight.Tests
             Assert.AreEqual("id", ((BetweenClause) syntax.Filter[0]).Column.FieldName);
             Assert.AreEqual(2, ((BetweenClause) syntax.Filter[0]).LowerValue);
             Assert.AreEqual(4, ((BetweenClause) syntax.Filter[0]).UpperValue);
-            results = syntax.QueryCollection<EmployeeObj>(list);
+            results = syntax.QueryCollection(list);
             Assert.AreEqual(6, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(e.id <= 1 || e.id >= 5);
+                Assert.IsTrue(e.id is <= 1 or >= 5);
             }
         }
 
@@ -217,7 +217,7 @@ namespace Searchlight.Tests
             Assert.AreEqual("A", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
+            var results = syntax.QueryCollection(list);
             Assert.AreEqual(1, results.records.Length);
             foreach (var e in results.records)
             {
@@ -240,7 +240,7 @@ namespace Searchlight.Tests
             Assert.AreEqual("s", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
+            var results = syntax.QueryCollection(list);
             Assert.AreEqual(2, results.records.Length);
             foreach (var e in results.records)
             {
@@ -263,20 +263,18 @@ namespace Searchlight.Tests
             Assert.AreEqual("s", ((CriteriaClause) syntax.Filter[0]).Value);
             
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
-            var resultsArr = results;
-            Assert.AreEqual(8, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            var results = syntax.QueryCollection(list);
+            Assert.AreEqual(8, results.records.Length);
+            foreach (var e in results.records)
             {
                 Assert.IsTrue(e != null && e.name.Contains('s', StringComparison.OrdinalIgnoreCase));
             }
             
             // Now test the opposite
             syntax = _src.Parse("name not contains 's'");
-            results = syntax.QueryCollection<EmployeeObj>(list);
-            resultsArr = results;
-            Assert.AreEqual(1, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            results = syntax.QueryCollection(list);
+            Assert.AreEqual(1, results.records.Length);
+            foreach (var e in results.records)
             {
                 Assert.IsTrue(e != null && (e.name == null || !e.name.Contains('s', StringComparison.OrdinalIgnoreCase)));
             }
@@ -295,10 +293,9 @@ namespace Searchlight.Tests
             Assert.AreEqual("b", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
-            var resultsArr = results;
-            Assert.AreEqual(7, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            var results = syntax.QueryCollection(list);
+            Assert.AreEqual(7, results.records.Length);
+            foreach (var e in results.records)
             {
                 Assert.IsTrue(string.Compare(e.name, "b", StringComparison.CurrentCultureIgnoreCase) > 0);
             }
@@ -317,12 +314,11 @@ namespace Searchlight.Tests
             Assert.AreEqual("bob rogers", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
-            var resultsArr = results;
-            Assert.AreEqual(7, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            var results = syntax.QueryCollection(list);
+            Assert.AreEqual(7, results.records.Length);
+            foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name.Substring(0, "bob rogers".Length), "bob rogers", StringComparison.CurrentCultureIgnoreCase) >= 0);
+                Assert.IsTrue(string.Compare(e.name[.."bob rogers".Length], "bob rogers", StringComparison.CurrentCultureIgnoreCase) >= 0);
             }
         }
         
@@ -339,10 +335,9 @@ namespace Searchlight.Tests
             Assert.AreEqual("b", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
-            var resultsArr = results;
-            Assert.AreEqual(1, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            var results = syntax.QueryCollection(list);
+            Assert.AreEqual(1, results.records.Length);
+            foreach (var e in results.records)
             {
                 Assert.IsTrue(string.Compare(e.name, "b", StringComparison.CurrentCultureIgnoreCase) < 0);
             }
@@ -361,12 +356,11 @@ namespace Searchlight.Tests
             Assert.AreEqual("bob rogers", ((CriteriaClause) syntax.Filter[0]).Value);
 
             // Execute the query and ensure that each result matches
-            var results = syntax.QueryCollection<EmployeeObj>(list);
-            var resultsArr = results;
-            Assert.AreEqual(2, resultsArr.records.Length);
-            foreach (var e in resultsArr.records)
+            var results = syntax.QueryCollection(list);
+            Assert.AreEqual(2, results.records.Length);
+            foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name.Substring(0, "bob rogers".Length), "bob rogers", StringComparison.CurrentCultureIgnoreCase) <= 0);
+                Assert.IsTrue(string.Compare(e.name[.."bob rogers".Length], "bob rogers", StringComparison.CurrentCultureIgnoreCase) <= 0);
             }
         }
 
@@ -377,7 +371,7 @@ namespace Searchlight.Tests
 
             var syntax = _src.Parse("Name != 'Alice Smith'");
 
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
 
             Assert.AreEqual(list.Count - 1, result.records.Length);
             Assert.IsFalse(result.records.Any(p => p.name == "Alice Smith"));
@@ -387,28 +381,10 @@ namespace Searchlight.Tests
         [TestMethod]
         public void BooleanContains()
         {
-            var list = GetTestList();
-
-            // Note that the "between" clause is inclusive
-            Assert.ThrowsException<FieldTypeMismatch>(() =>
-            {
-                var syntax = _src.Parse("onduty contains 's'");
-            });
-            Assert.ThrowsException<FieldTypeMismatch>(() =>
-                {
-                    var syntax = _src.Parse("onduty contains True");
-                }
-            );
-            Assert.ThrowsException<FieldTypeMismatch>(() =>
-                {
-                    var syntax = _src.Parse("onduty startswith True");
-                }
-            );
-            Assert.ThrowsException<FieldTypeMismatch>(() =>
-                {
-                    var syntax = _src.Parse("onduty endswith True");
-                }
-            );
+            Assert.ThrowsException<FieldTypeMismatch>(() => { _src.Parse("OnDuty contains 's'"); });
+            Assert.ThrowsException<FieldTypeMismatch>(() => { _src.Parse("OnDuty contains True"); });
+            Assert.ThrowsException<FieldTypeMismatch>(() => { _src.Parse("OnDuty startswith True"); });
+            Assert.ThrowsException<FieldTypeMismatch>(() => { _src.Parse("OnDuty endswith True"); });
         }
 
 
@@ -418,14 +394,14 @@ namespace Searchlight.Tests
             var list = GetTestList();
 
             var syntax = _src.Parse("Name is NULL");
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.records.Any());
             Assert.AreEqual(1, result.records.Length);
             
             // Test the opposite
             syntax = _src.Parse("Name is not NULL");
-            result = syntax.QueryCollection<EmployeeObj>(list);
+            result = syntax.QueryCollection(list);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.records.Any());
             Assert.AreEqual(8, result.records.Length);
@@ -436,11 +412,11 @@ namespace Searchlight.Tests
         public void ContainsNull()
         {
             var list = GetTestList();
-            // Searchlight interprets the un-apostrophed word "null" here to be the string value "null"
+            // Searchlight interprets the word "null" without apostrophes here to be the string value "null"
             // instead of a null.
             var syntax = _src.Parse("Name contains null");
 
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
             Assert.IsNotNull(result);
             Assert.AreEqual(1, result.records.Length);
             Assert.IsTrue(result.records.Any(p => p.name == "Roderick 'null' Sqlkeywordtest"));
@@ -454,7 +430,7 @@ namespace Searchlight.Tests
 
             var syntax = _src.Parse("name in ('Alice Smith', 'Bob Rogers', 'Sir Not Appearing in this Film')");
 
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
 
             Assert.IsTrue(result.records.Any(p => p.name == "Alice Smith"));
             Assert.IsTrue(result.records.Any(p => p.name == "Bob Rogers"));
@@ -463,7 +439,7 @@ namespace Searchlight.Tests
         
             // Now run the opposite query
             syntax = _src.Parse("name not in ('Alice Smith', 'Bob Rogers', 'Sir Not Appearing in this Film')"); 
-            result = syntax.QueryCollection<EmployeeObj>(list);
+            result = syntax.QueryCollection(list);
 
             Assert.IsFalse(result.records.Any(p => p.name == "Alice Smith"));
             Assert.IsFalse(result.records.Any(p => p.name == "Bob Rogers"));
@@ -473,14 +449,14 @@ namespace Searchlight.Tests
 
 
         [TestMethod]
-        public void InQueryInts()
+        public void InQueryInt()
         {
             var list = GetTestList();
             // getting not implemented error on this line
             // make sure using right formatting, if so then in operator needs adjustment
             var syntax = _src.Parse("id in (1,2,57)");
 
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
 
             Assert.IsTrue(result.records.Any(p => p.id == 1));
             Assert.IsTrue(result.records.Any(p => p.id == 2));
@@ -516,7 +492,7 @@ namespace Searchlight.Tests
 
             var syntax = _src.Parse("name eq 'ALICE SMITH'");
 
-            var result = syntax.QueryCollection<EmployeeObj>(list);
+            var result = syntax.QueryCollection(list);
 
             Assert.IsTrue(result.records.Any(p => p.name == "Alice Smith"));
             Assert.IsNotNull(result);
@@ -524,7 +500,7 @@ namespace Searchlight.Tests
             
             // Try the inverse
             syntax = _src.Parse("name not eq 'ALICE SMITH'");
-            result = syntax.QueryCollection<EmployeeObj>(list);
+            result = syntax.QueryCollection(list);
             Assert.IsFalse(result.records.Any(p => p.name == "Alice Smith"));
             Assert.IsNotNull(result);
             Assert.AreEqual(list.Count - 1, result.records.Length);
@@ -693,15 +669,13 @@ namespace Searchlight.Tests
             {
                 Assert.AreEqual(result.records[i].hired, control[i].hired);
             }
-            
-            //TODO: add test that sorts multiple fields
         }
 
         [TestMethod]
         public void DefaultReturn()
         {
             var list = GetTestList();
-            var syntax = _src.Parse("", null, null);
+            var syntax = _src.Parse("");
             syntax.PageNumber = 0; // default is 0
             syntax.PageSize = 0; // default is 0
             
@@ -715,7 +689,7 @@ namespace Searchlight.Tests
         public void PageNumberNoPageSize()
         {
             var list = GetTestList();
-            var syntax = _src.Parse("", null, null);
+            var syntax = _src.Parse("");
             syntax.PageNumber = 2;
             syntax.PageSize = 0; // default is 0
 
@@ -729,7 +703,7 @@ namespace Searchlight.Tests
         public void PageSizeNoPageNumber()
         {
             var list = GetTestList();
-            var syntax = _src.Parse("", null, null);
+            var syntax = _src.Parse("");
             
             syntax.PageSize = 2;
             syntax.PageNumber = 0; // no page number defaults to 0
@@ -744,7 +718,7 @@ namespace Searchlight.Tests
         public void PageSizeAndPageNumber()
         {
             var list = GetTestList();
-            var syntax = _src.Parse("", null, null);
+            var syntax = _src.Parse("");
             syntax.PageSize = 1;
             syntax.PageNumber = 2;
 

--- a/tests/Searchlight.Tests/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/LinqExecutorTests.cs
@@ -7,6 +7,8 @@ using System.Linq;
 // This file has lots of intentional misspellings
 // ReSharper disable StringLiteralTypo
 // ReSharper disable CommentTypo
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable IdentifierTypo
 
 // Highlighting allocations on this file is annoying 
 // ReSharper disable HeapView.DelegateAllocation
@@ -17,10 +19,8 @@ namespace Searchlight.Tests
     public class LinqExecutorTests
     {
         private readonly DataSource _src;
-        private static List<EmployeeObj> _list;
         
         [SearchlightModel(DefaultSort = nameof(name))]
-        // ReSharper disable once MemberCanBePrivate.Global
         public class EmployeeObj
         {
             public string name { get; set; }
@@ -30,9 +30,64 @@ namespace Searchlight.Tests
             public bool onduty { get; set; }
         }
 
+        public class CompatibleEmployeeObj
+        {
+            public string name { get; set; }
+            public int? id { get; set; }
+            public string hired { get; set; }
+            public string paycheck { get; set; }
+            public bool? onduty { get; set; }
+        }
+
+        public class IncompatibleEmployeeObj
+        {
+            public string FullName { get; set; }
+            public int Identifier { get; set; }
+        }
+
+        private static List<IncompatibleEmployeeObj> GetIncompatibleList()
+        {
+            return new List<IncompatibleEmployeeObj>()
+            {
+                new IncompatibleEmployeeObj()
+                {
+                    FullName = "Irving Incompatible",
+                    Identifier = 1,
+                },
+                new IncompatibleEmployeeObj()
+                {
+                    FullName = "Noreen Negative",
+                    Identifier = -1,
+                }
+            };
+        }
+
+        private static List<CompatibleEmployeeObj> GetCompatibleList()
+        {
+            return new List<CompatibleEmployeeObj>()
+            {
+                new CompatibleEmployeeObj()
+                {
+                    name = "Charlie Compatible",
+                    id = 57,
+                    hired = "true",
+                    paycheck = "$1000.00",
+                    onduty = false
+                },
+                new CompatibleEmployeeObj()
+                {
+                    name = "Nelly Null",
+                    id = null,
+                    hired = null,
+                    paycheck = null,
+                    onduty = null
+                },
+            };
+        }
+
         private static List<EmployeeObj> GetTestList()
         {
-            return _list ??= new List<EmployeeObj>
+            return new List<EmployeeObj>
             {
                 new()
                     { hired = DateTime.Today, id = 1, name = "Alice Smith", onduty = true, paycheck = 1000.00m },
@@ -568,17 +623,16 @@ namespace Searchlight.Tests
         {
             // id test ascending and descending
             var list = GetTestList();
-            var control = (from item in GetTestList() orderby item.id ascending select item).ToList();
+            var control = (from item in list orderby item.id ascending select item).ToList();
             var syntax = _src.Parse(null, null, "id ASC");
             var result = syntax.QueryCollection(list);
             
-            for (int i = 0; i < list.Count; i++)
+            for (var i = 0; i < list.Count; i++)
             {
                 Assert.AreEqual(result.records[i].id, control[i].id);
             }
             
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.id descending select item).ToList();
+            control = (from item in list orderby item.id descending select item).ToList();
             syntax = _src.Parse("", null, "id descending");
             result = syntax.QueryCollection(list);
 
@@ -588,8 +642,7 @@ namespace Searchlight.Tests
             }
             
             // name test ascending and descending
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.name ascending select item).ToList();
+            control = (from item in list orderby item.name ascending select item).ToList();
             syntax = _src.Parse("", null, "name ASC");
             result = syntax.QueryCollection(list);
             
@@ -598,8 +651,7 @@ namespace Searchlight.Tests
                 Assert.AreEqual(result.records[i].name, control[i].name);
             }
             
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.name descending select item).ToList();
+            control = (from item in list orderby item.name descending select item).ToList();
             syntax = _src.Parse("", null, "name DESC");
             result = syntax.QueryCollection(list);
             
@@ -609,8 +661,7 @@ namespace Searchlight.Tests
             }
             
             // paycheck test ascending and descending
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.paycheck ascending select item).ToList();
+            control = (from item in list orderby item.paycheck ascending select item).ToList();
             syntax = _src.Parse("", null, "paycheck ASC");
             result = syntax.QueryCollection(list);
 
@@ -619,8 +670,7 @@ namespace Searchlight.Tests
                 Assert.AreEqual(result.records[i].paycheck, control[i].paycheck);
             }
             
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.paycheck descending select item).ToList();
+            control = (from item in list orderby item.paycheck descending select item).ToList();
             syntax = _src.Parse("", null, "paycheck DESC");
             result = syntax.QueryCollection(list);
             
@@ -630,8 +680,7 @@ namespace Searchlight.Tests
             }
             
             // onduty test ascending and descending
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.onduty ascending select item).ToList();
+            control = (from item in list orderby item.onduty ascending select item).ToList();
             syntax = _src.Parse("", null, "onduty ASC");
             result = syntax.QueryCollection(list);
             
@@ -640,8 +689,7 @@ namespace Searchlight.Tests
                 Assert.AreEqual(result.records[i].onduty, control[i].onduty);
             }
             
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.onduty descending select item).ToList();
+            control = (from item in list orderby item.onduty descending select item).ToList();
             syntax = _src.Parse("", null, "onduty DESC");
             result = syntax.QueryCollection(list);
             
@@ -651,8 +699,7 @@ namespace Searchlight.Tests
             }
             
             // hired test ascending and descending
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.hired ascending select item).ToList();
+            control = (from item in list orderby item.hired ascending select item).ToList();
             syntax = _src.Parse("", null, "hired ASC");
             result = syntax.QueryCollection(list);
             
@@ -661,8 +708,7 @@ namespace Searchlight.Tests
                 Assert.AreEqual(result.records[i].hired, control[i].hired);
             }
             
-            list = GetTestList();
-            control = (from item in GetTestList() orderby item.hired descending select item).ToList();
+            control = (from item in list orderby item.hired descending select item).ToList();
             syntax = _src.Parse("", null, "hired DESC");
             result = syntax.QueryCollection(list);
             for (var i = 0; i < list.Count; i++)
@@ -725,6 +771,36 @@ namespace Searchlight.Tests
             var result = syntax.QueryCollection(list);
             
             Assert.AreEqual(result.records.Length, 1);
+        }
+
+        [TestMethod]
+        public void QueryCompatibleCollection()
+        {
+            var list = GetCompatibleList();
+            var syntax = _src.Parse("name startswith c and id = 57 and hired > 2020-02-01 and onduty = false");
+            syntax.PageSize = 1;
+            syntax.PageNumber = 2;
+
+            var result = syntax.QueryCollection(list);
+            
+            Assert.AreEqual(result.records.Length, 1);
+            Assert.AreEqual("Charlie Compatible", result.records[0].name);
+            Assert.AreEqual(57, result.records[0].id);
+            Assert.AreEqual("true", result.records[0].hired);
+            Assert.AreEqual("$1000.00", result.records[0].paycheck);
+            Assert.AreEqual(false, result.records[0].onduty);
+        }
+
+        [TestMethod]
+        public void QueryIncompatibleCollection()
+        {
+            var list = GetIncompatibleList();
+            var syntax = _src.Parse("name startswith a");
+            syntax.PageSize = 1;
+            syntax.PageNumber = 2;
+
+            var ex = Assert.ThrowsException<FieldNotFound>(() => { _ = syntax.QueryCollection(list); });
+            Assert.AreEqual("name", ex.FieldName);
         }
     }
 }


### PR DESCRIPTION
If you accidentally run the LINQ executor on a different type than Searchlight understands, there is a risk that your field types won't match exactly.  The scenario in question is a potential risk when you have different data models for an entity (representing the database) and a model (representing the API).  

This code adds assertions that verify whether the problem has occurred and throws appropriate Searchlight errors.