### PR TITLE
Updated some tests and increased version number

### DIFF
--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,3 +1,20 @@
+# 0.9.22
+November 10, 2022
+
+Updated some exceptions to include more readable error message values.
+
+# 0.9.21
+March 29, 2022
+
+* Implementation of Searchlight for MongoDB
+* All test cases run against MongoDB in the same form that they run against in-memory collections
+* Works using the official C# MongoDB driver
+* Refactored the test suite to make comparisons across different databases/executors easier 
+
+Future improvements planned for MongoDB: 
+* Case insensitive string comparison
+* Searchlight collections support
+* 
 # 0.9.20
 March 15, 2022
 

--- a/Searchlight.MongoDB.nuspec
+++ b/Searchlight.MongoDB.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight.MongoDB</id>
-		<version>0.9.21</version>
+		<version>0.9.22</version>
 		<title>Searchlight.MongoDB</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -16,17 +16,10 @@
 		<summary>Implements the Searchlight query engine on top of MongoDB.</summary>
 		<icon>docs/icons8-searchlight-90.png</icon>
 		<releaseNotes>
-			# 0.9.21
-			March 29, 2022
+			# 0.9.22
+			November 10, 2022
 
-			* Implementation of Searchlight for MongoDB
-			* All test cases run against MongoDB in the same form that they run against in-memory collections
-			* Works using the official C# MongoDB driver
-			* Refactored the test suite to make comparisons across different databases/executors easier 
-			
-			Future improvements planned for MongoDB: 
-			* Case insensitive string comparison
-			* Searchlight collections support
+			Updated some exceptions to include more readable error message values.
 		</releaseNotes>
 		<copyright>Copyright 2013 - 2022</copyright>
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.9.21</version>
+		<version>0.9.22</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -16,10 +16,10 @@
 		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
 		<icon>docs/icons8-searchlight-90.png</icon>
 		<releaseNotes>
-			# 0.9.21
-			March 15, 2022
-
-			* Support for date math in searchlight queries, such as `dateDue between NOW and NOW + 7`
+			# 0.9.22
+			November 10, 2022
+			
+			Updated some exceptions to include more readable error message values.
 		</releaseNotes>
 		<copyright>Copyright 2013 - 2022</copyright>
     	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>

--- a/src/Searchlight/Exceptions/InvalidToken.cs
+++ b/src/Searchlight/Exceptions/InvalidToken.cs
@@ -18,9 +18,8 @@ namespace Searchlight
 
         public string ErrorMessage
         {
-            get => $"The filter statement contained an unexpected token, {BadToken}. Searchlight expects to find one of these next:" +
-                   $"{string.Join(", ", ExpectedTokens)}. Example: `(name eq Alice) date eq '2021-09-29'` In this query, Searchlight expects to see " +
-                   "\"AND\" or \"OR\" after the close parenthesis.";
+            get => $"The filter statement contained an unexpected token, '{BadToken}'. Searchlight expects to find one of these next: " +
+                   $"{string.Join(", ", ExpectedTokens)}";
         }
     }
 }

--- a/tests/Searchlight.Tests/FlagTests.cs
+++ b/tests/Searchlight.Tests/FlagTests.cs
@@ -76,6 +76,7 @@ namespace Searchlight.Tests
             Assert.AreEqual("AnUnknownAlias", ex.IncludeName);
             Assert.AreEqual("TestFlag, AnUnknownAlias, AnotherUnknownAliasButThisOneDoesntGetTestedBecauseTheFirstOneFails", ex.OriginalInclude);
             Assert.IsTrue(ex.KnownIncludes.Contains("TestFlag"));
+            Assert.IsTrue(ex.ErrorMessage.EndsWith("known includes for available values: TestFlag, TestTwo."));
             
             // Check whether two flags can be specified
             syntax = engine.Parse(new FetchRequest()

--- a/tests/Searchlight.Tests/ParseModelTests.cs
+++ b/tests/Searchlight.Tests/ParseModelTests.cs
@@ -48,6 +48,7 @@ namespace Searchlight.Tests
             var ex = Assert.ThrowsException<FieldNotFound>(() => source.ParseFilter(originalFilter));
             Assert.AreEqual("a", ex.FieldName);
             Assert.AreEqual(originalFilter, ex.OriginalFilter);
+            Assert.IsTrue(ex.ErrorMessage.EndsWith("Check the list of known fields to see if the filter contains a typographical error: NAME, DESCRIPTION"));
 
             // Attempt to query a field that does exist, but is not permitted to be queried
             originalFilter = "NotASearchlightField = 'Hello'";

--- a/tests/Searchlight.Tests/SqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/SqlExecutorTests.cs
@@ -106,6 +106,7 @@ namespace Searchlight.Tests
             Assert.AreEqual("[1", ex.BadToken);
             Assert.AreEqual(1, ex.ExpectedTokens.Length);
             Assert.IsTrue(ex.ExpectedTokens.Contains("("));
+            Assert.IsTrue(ex.ErrorMessage.EndsWith("Searchlight expects to find one of these next: ("));
 
             // Error in "IS NULL" clause
             originalFilter = "b is not complex and should have been just called 'NULL'";


### PR DESCRIPTION
Based on work from @AlexRussak , this PR changes some of our error messages to make them more readable.  Incremented version number to 0.9.22 and updated some tests to assert these new strings appear as expected.