### PR TITLE
Update version number and configure to automatically publish

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,8 +3,6 @@ name: NuGet Publish
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,40 @@
+name: NuGet Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Update NuGet package
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Setup .NET Core @ Latest
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "7.0.x"
+          include-prerelease: false
+
+      - name: Build solution and generate NuGet package
+        run: dotnet build -c Release
+
+      - name: Setup Nuget
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+          nuget-version: "5.x"
+
+      - name: Run Nuget pack
+        run: nuget pack Searchlight.nuspec
+
+      - name: Push generated package to GitHub registry
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,3 +1,14 @@
+# 1.0.0
+July 13, 2023
+
+Significant work on testing Searchlight:
+* Added integration tests for Postgres, MongoDB, and SQL Server.
+* Added SonarCloud for analyzing potential vulnerabilities.
+* Report an error when a compound clause contains both AND and OR statements.  This prevents unclear order-of-operations risks when someone specifies (A and B or C).
+* Fixed issues with negated queries.  If a user specifies "not eq"
+* Addressed test issues with dates and time zones and evaluation of nullability of generic collections vs databases
+* Addressed issues with escaping of string values; fixes issue where an end user searches for a string containing percentage signs
+
 # 0.9.22
 November 10, 2022
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![NuGet](https://img.shields.io/nuget/v/Searchlight.svg?style=plastic)](https://www.nuget.org/packages/Searchlight/)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/tspence/csharp-searchlight/dotnet.yml?branch=main)
-[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=coverage)](https://sonarcloud.io/component_measures/metric/coverage/list?id=tspence_csharp-searchlight)
-[![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=bugs)](https://sonarcloud.io/component_measures/metric/reliability_rating/list?id=tspence_csharp-searchlight)
-[![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=vulnerabilities)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=tspence_csharp-searchlight)
+[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=coverage)](https://sonarcloud.io/summary/overall?id=tspence_csharp-searchlight)
+[![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=bugs)](https://sonarcloud.io/summary/overall?id=tspence_csharp-searchlight)
+[![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=tspence_csharp-searchlight&metric=vulnerabilities)](https://sonarcloud.io/summary/overall?id=tspence_csharp-searchlight)
 
 # Searchlight
 
@@ -11,7 +11,25 @@ A lightweight, secure query language for searching through databases and in-memo
 # What is Searchlight?
 
 Searchlight is a simple and safe query language for API design.  [Designed with security in mind](https://tedspence.com/protecting-apis-with-layered-security-8c989fb5a19f), 
-it works well with REST, provides complex features, and is easier to learn than GraphQL.  
+it works well with REST, provides complex features, and is easier to learn than GraphQL or OData.  
+
+Both OData and GraphQL are designed to help programmers write queries.  Searchlight is designed to help real human beings 
+write queries.  Because of its focus on human readability, Searchlight queries can be exposed to end users and they will
+generally make sense and be readable.
+
+Compare these alternatives:
+
+| Language | Example | Explanation |
+|---|---|---|
+| Searchlight | `name startswith A or status = 'Active'` | Friendly and readable |
+| OData | `(startswith(name, 'A')) or (status eq 'Active')` | Functions in OData are designed with programmers in mind, not humans. |
+| GraphQL | `{ { name: "A%" } or: { status: "Active" } }` | GraphQL is designed to be written in JSON, not english. |
+
+Many programmers find that OData and GraphQL are required for certain types of integration, but Searchlight can be integrated
+to make it easy for end users to work with your code.  In fact, you can convert a Searchlight query into an OData query using
+the Linq executor.
+
+# Key features of Searchlight
 
 * **Fast**
 Searchlight uses precalculated search tables for performance of roughly 24 microseconds per six calls to Parse, or about 4
@@ -20,30 +38,22 @@ microseconds per FetchRequest object parsed.
 As a compiled language, the Searchlight query language is safe from SQL injection attacks.  Malformed queries generate clear
 error messages within Searchlight, and if you choose to use Searchlight on top of an SQL database, all queries executed on 
 your database will use parameterized values.
-* **Database independent**
-You can use Searchlight against SQL databases, NoSQL databases, or in-memory collections.  If you change your mind later
-and decide to switch to a different database technology, Searchlight still works.
-* **Search in memory**
-With Searchlight, you can search in-memory collections or use REDIS to cache data.  You can still search the data just like
-it was in a SQL-based database.
-* **Powerful queries**
-Searchlight lets you execute complex search statements such as `in`, `startsWith`, `contains`, and others.  You can create
-complex queries using parenthesis and conjunctions (AND/OR).
-* **Reduce database usage**
-You can use Searchlight to make multiple-result-set database calls with an SQL database to avoid executing multiple
-fetch statements.
-* **Self-documenting**
-If you mistype the name of a field, you get an error that indicates exactly which field name was misspelled, and a list of all
-known fields you can use.
-* **Standardized queries**
-The Searchlight API pattern allows for filtering, fetching extra data, sorting, and pagination.  
-* **Programmatic control**
-You can examine the Searchlight abstract syntax tree for performance problems, inappropriate filters, or query statements
-too complex for your database and reject those queries before they waste unnecessary query cycles on your data store.
 * **Human readable**
 Unlike JSON-based query systems, Searchlight is easily readable and should be familiar to most people who are comfortable
 using SQL and LINQ languages.  Searchlight uses words instead of symbols to avoid unnecessary escaping rules for HTML and HTTP
 requests.
+* **Database independent**
+You can use Searchlight against SQL databases, NoSQL databases, or in-memory collections.  If you change your mind later
+and decide to switch to a different database technology, Searchlight still works.
+* **Powerful queries**
+Searchlight lets you execute complex search statements such as `in`, `startsWith`, `contains`, and others.  You can create
+complex queries using parenthesis and conjunctions (AND/OR).
+* **Self-documenting**
+If you mistype the name of a field, you get an error that indicates exactly which field name was misspelled, and a list of all
+known fields you can use.
+* **Programmatic control**
+You can examine the Searchlight abstract syntax tree for performance problems, inappropriate filters, or query statements
+too complex for your database and reject those queries before they waste unnecessary query cycles on your data store.
 
 # Using Searchlight
 The typical API pattern for Searchlight works as follows:
@@ -241,21 +251,4 @@ public class MyAccount
     [SearchlightField(Aliases = new string[] { "OldName", "NewName", "TransitionalName" })]
     public string AccountName { get; set; }
 }
-```
-
-# Constructing Searchlight models programmatically
-
-Constructing a model manually works as follows:
-
-```csharp
-var source = new SearchlightDataSource()
-    .WithColumn("a", typeof(String), null)
-    .WithColumn("b", typeof(Int32), null)
-    .WithColumn("colLong", typeof(Int64), null)
-    .WithColumn("colNullableGuid", typeof(Nullable<Guid>), null)
-    .WithColumn("colULong", typeof(UInt64), null)
-    .WithColumn("colNullableULong", typeof(Nullable<UInt64>), null)
-    .WithColumn("colGuid", typeof(Guid), null);
-source.MaximumParameters = 200;
-source.DefaultSortField = "a";
 ```

--- a/Searchlight.nuspec
+++ b/Searchlight.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>Searchlight</id>
-		<version>0.9.22</version>
+		<version>1.0.0</version>
 		<title>Searchlight</title>
 		<authors>Ted Spence</authors>
 		<owners>Ted Spence</owners>
@@ -11,18 +11,25 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<readme>docs/README.md</readme>
 		<description>
-			A lightweight, secure query language for searching through databases and in-memory collections using a fluent REST API with robust, secure searching features.
+			A lightweight, secure, and human readable domain-specific query language for searching through databases and in-memory collections.  
+			Works alongside REST, GraphQL, and OData to make human readable API queries possible.
 		</description>
-		<summary>Be fully database independent with the Searchlight query parser and execution engine for your REST API.</summary>
+		<summary>A friendly and readable domain specific query language for your API.</summary>
 		<icon>docs/icons8-searchlight-90.png</icon>
 		<releaseNotes>
-			# 0.9.22
-			November 10, 2022
+			# 1.0.0
+			July 13, 2023
 			
-			Updated some exceptions to include more readable error message values.
+			Significant work on testing Searchlight:
+			* Added integration tests for Postgres, MongoDB, and SQL Server.
+			* Added SonarCloud for analyzing potential vulnerabilities.
+			* Report an error when a compound clause contains both AND and OR statements.  This prevents unclear order-of-operations risks when someone specifies (A and B or C).
+			* Fixed issues with negated queries.  If a user specifies "not eq"
+			* Addressed test issues with dates and time zones and evaluation of nullability of generic collections vs databases
+			* Addressed issues with escaping of string values; fixes issue where an end user searches for a string containing percentage signs
 		</releaseNotes>
-		<copyright>Copyright 2013 - 2022</copyright>
-    	<tags>REST query language abstract syntax tree parser sql-injection protection</tags>
+		<copyright>Copyright 2013 - 2023</copyright>
+    	<tags>REST query language abstract syntax tree parser sql-injection protection friendly readable domain-specific DSL</tags>
 		<repository type="git" url="https://github.com/tspence/csharp-searchlight" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0"/>

--- a/Searchlight.sln
+++ b/Searchlight.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other Files", "Other Files"
 		icons8-searchlight-90.png = icons8-searchlight-90.png
 		Searchlight.MongoDB.nuspec = Searchlight.MongoDB.nuspec
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+		.github\workflows\nuget-publish.yml = .github\workflows\nuget-publish.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchlightPerformance", "src\SearchlightPerformance\SearchlightPerformance.csproj", "{64285A31-2226-4BF5-A587-0A4E9A90B9C7}"


### PR DESCRIPTION
Let's make this easier - we can auto-publish Searchlight when changes are applied to main.

We'll also bump the version number to 1.0 since this now has automated integration tests for Postgres, SQL Server, and MongoDB.  I should probably add support for MySQL and SQLite as well.