### PR TITLE
Add StringComparison option for Case Sensitivity

### DIFF
--- a/src/Searchlight/Exceptions/InvalidEngineSetting.cs
+++ b/src/Searchlight/Exceptions/InvalidEngineSetting.cs
@@ -1,0 +1,27 @@
+﻿namespace Searchlight.Exceptions
+{
+    /// <summary>
+    /// Exception to be thrown if the SearchlightEngine was configured incorrectly
+    /// </summary>
+    public class InvalidEngineSetting : SearchlightException
+    {
+        public string OriginalFilter { get; internal set; }
+
+        /// <summary>
+        /// Fields that are missing or incorrect
+        /// </summary>
+        public string[] Fields { get; set; }
+
+        public string ErrorMessage =>
+            $"These fields are either missing or are set incorrectly: {string.Join(",", Fields)}";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fields"></param>
+        public InvalidEngineSetting(params string[] fields)
+        {
+            Fields = fields;
+        }
+    }
+}

--- a/src/Searchlight/LinqExecutor.cs
+++ b/src/Searchlight/LinqExecutor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Searchlight.Parsing;
 using Searchlight.Query;
 
@@ -149,6 +150,7 @@ namespace Searchlight
             Expression field;
             Expression value;
             Expression result;
+            var comparison = src?.Engine?.StringComparison ?? StringComparison.OrdinalIgnoreCase;
 
             var t = typeof(T);
 
@@ -173,7 +175,7 @@ namespace Searchlight
                                     // ReSharper disable once AssignNullToNotNullAttribute
                                     typeof(string).GetMethod("Equals",
                                         new [] { typeof(string), typeof(string), typeof(StringComparison) }),
-                                    field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase));
+                                    field, value, Expression.Constant(comparison));
                             }
                             else
                             {
@@ -191,7 +193,7 @@ namespace Searchlight
                                                 {
                                                     typeof(string), typeof(string), typeof(StringComparison)
                                                 }),
-                                            field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                            field, value, Expression.Constant(comparison)),
                                         Expression.Constant(0)));
                             }
                             else
@@ -210,7 +212,7 @@ namespace Searchlight
                                                 {
                                                     typeof(string), typeof(string), typeof(StringComparison)
                                                 }),
-                                            field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                            field, value, Expression.Constant(comparison)),
                                         Expression.Constant(0)));
                             }
                             else
@@ -229,7 +231,7 @@ namespace Searchlight
                                                 {
                                                     typeof(string), typeof(string), typeof(StringComparison)
                                                 }),
-                                            field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                            field, value, Expression.Constant(comparison)),
                                         Expression.Constant(0)));
                             }
                             else
@@ -248,7 +250,7 @@ namespace Searchlight
                                                 {
                                                     typeof(string), typeof(string), typeof(StringComparison)
                                                 }),
-                                            field, value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                            field, value, Expression.Constant(comparison)),
                                         Expression.Constant(0)));
                             }
                             else
@@ -262,7 +264,7 @@ namespace Searchlight
                                     // ReSharper disable once AssignNullToNotNullAttribute
                                     typeof(string).GetMethod("StartsWith",
                                         new [] { typeof(string), typeof(StringComparison) }),
-                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                    value, Expression.Constant(comparison)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );
@@ -274,7 +276,7 @@ namespace Searchlight
                                     // ReSharper disable once AssignNullToNotNullAttribute
                                     typeof(string).GetMethod("EndsWith",
                                         new [] { typeof(string), typeof(StringComparison) }),
-                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                    value, Expression.Constant(comparison)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );
@@ -285,7 +287,7 @@ namespace Searchlight
                                     // ReSharper disable once AssignNullToNotNullAttribute
                                     typeof(string).GetMethod("Contains",
                                         new [] { typeof(string), typeof(StringComparison) }),
-                                    value, Expression.Constant(StringComparison.OrdinalIgnoreCase)),
+                                    value, Expression.Constant(comparison)),
                                 Expression.MakeCatchBlock(typeof(Exception), null,
                                     Expression.Constant(false, typeof(Boolean)), null)
                             );

--- a/src/Searchlight/SearchlightEngine.cs
+++ b/src/Searchlight/SearchlightEngine.cs
@@ -64,6 +64,23 @@ namespace Searchlight
         public bool useNoCount { get; set; } = true;
 
         /// <summary>
+        /// Whether or not to use case sensitive comparisons
+        ///
+        /// Note: Odd numbers in the StringComparison enum are case sensitive
+        /// </summary>
+        public bool CaseSensitiveComparison => (int)StringComparison % 2 == 0;
+
+        /// <summary>
+        /// The string comparison for the engine
+        /// </summary>
+        public StringComparison StringComparison { get; set; } = StringComparison.OrdinalIgnoreCase;
+
+        /// <summary>
+        /// The collation to use for case sensitive comparisons, must be specified for SQL Server
+        /// </summary>
+        public string Collation { get; set; } = string.Empty;
+
+        /// <summary>
         /// Adds a new class to the engine
         /// </summary>
         /// <param name="type"></param>

--- a/src/Searchlight/SqlExecutor.cs
+++ b/src/Searchlight/SqlExecutor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Searchlight.Exceptions;
 using Searchlight.Query;
 
@@ -62,7 +63,7 @@ namespace Searchlight
         private static SqlQuery CreateSql(SqlDialect dialect, SyntaxTree query, SearchlightEngine engine)
         {
             var sql = new SqlQuery() { Syntax = query };
-            sql.WhereClause = RenderJoinedClauses(dialect, query.Filter, sql);
+            sql.WhereClause = RenderJoinedClauses(dialect, query.Filter, sql, engine);
             sql.OrderByClause = RenderOrderByClause(query.OrderBy);
 
             // Sanity test - is the query too complicated to be safe to run?
@@ -172,7 +173,7 @@ namespace Searchlight
         /// <param name="clause"></param>
         /// <param name="sql"></param>
         /// <returns></returns>
-        private static string RenderJoinedClauses(SqlDialect dialect, List<BaseClause> clause, SqlQuery sql)
+        private static string RenderJoinedClauses(SqlDialect dialect, List<BaseClause> clause, SqlQuery sql, SearchlightEngine engine)
         {
             var sb = new StringBuilder();
             for (var i = 0; i < clause.Count; i++)
@@ -193,7 +194,7 @@ namespace Searchlight
                     }
                 }
 
-                sb.Append(RenderClause(dialect, clause[i], sql));
+                sb.Append(RenderClause(dialect, clause[i], sql, engine));
             }
 
             return sb.ToString();
@@ -207,7 +208,7 @@ namespace Searchlight
         /// <param name="sql"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        private static string RenderClause(SqlDialect dialect, BaseClause clause, SqlQuery sql)
+        private static string RenderClause(SqlDialect dialect, BaseClause clause, SqlQuery sql, SearchlightEngine engine)
         {
             switch (clause)
             {
@@ -215,7 +216,7 @@ namespace Searchlight
                     return
                         $"{bc.Column.OriginalName} {(bc.Negated ? "NOT " : "")}BETWEEN {sql.AddParameter(bc.LowerValue.GetValue(), bc.Column.FieldType)} AND {sql.AddParameter(bc.UpperValue.GetValue(), bc.Column.FieldType)}";
                 case CompoundClause compoundClause:
-                    return $"({RenderJoinedClauses(dialect, compoundClause.Children, sql)})";
+                    return $"({RenderJoinedClauses(dialect, compoundClause.Children, sql, engine)})";
                 case CriteriaClause cc:
                     var rawValue = cc.Value.GetValue();
                     switch (cc.Operation)
@@ -226,7 +227,8 @@ namespace Searchlight
                         case OperationType.LessThan:
                         case OperationType.LessThanOrEqual:
                         case OperationType.NotEqual:
-                            return RenderComparisonClause(cc.Column.OriginalName, cc.Negated, cc.Operation, sql.AddParameter(rawValue, cc.Column.FieldType));
+                            return RenderComparisonClause(dialect, cc,
+                                sql.AddParameter(rawValue, cc.Column.FieldType), engine);
                         case OperationType.Contains:
                             return RenderLikeClause(dialect, cc, sql, rawValue, "%", "%");
                         case OperationType.StartsWith:
@@ -257,15 +259,51 @@ namespace Searchlight
             { OperationType.GreaterThanOrEqual, new Tuple<string, string>(">=", "<") },
         };
         
-        private static string RenderComparisonClause(string column, bool negated, OperationType op, string parameter)
+        private static string RenderComparisonClause(SqlDialect dialect, CriteriaClause cc, string parameter, SearchlightEngine engine)
         {
+            var op = cc.Operation;
+            var negated = cc.Negated;
+            var column = cc.Column.OriginalName;
+            var fieldType = cc.Column.FieldType;
+            
             if (!CanonicalOps.TryGetValue(op, out var opstrings))
             {
                 throw new Exception($"Invalid comparison type {op}");
             }
 
             var operationSymbol = negated ? opstrings.Item2 : opstrings.Item1;
-            return $"{column} {operationSymbol} {parameter}";
+
+            if (engine.CaseSensitiveComparison)
+            {
+                switch (dialect)
+                {
+                    case SqlDialect.MicrosoftSqlServer:
+                        if (string.IsNullOrEmpty(engine.Collation))
+                        {
+                            throw new InvalidEngineSetting(nameof(SearchlightEngine.Collation));
+                        }
+                        
+                        return $"{column} {operationSymbol} {parameter} COLLATE {engine.Collation}";
+                    case SqlDialect.MySql:
+                        return $"{column} {operationSymbol} BINARY {parameter}";
+                    case SqlDialect.PostgreSql:
+                    default:
+                        return $"{column} {operationSymbol} {parameter}";
+                }
+            }
+
+            // Case insensitive comparison
+            switch (dialect)
+            {
+                case SqlDialect.PostgreSql:
+                    return fieldType == typeof(string)
+                        ? $"LOWER({column}) {operationSymbol} LOWER({parameter})"
+                        : $"{column} {operationSymbol} {parameter}";
+                case SqlDialect.MySql:
+                case SqlDialect.MicrosoftSqlServer:
+                default:
+                    return $"{column} {operationSymbol} {parameter}";
+            }
         }
 
         private static string RenderLikeClause(SqlDialect dialect, CriteriaClause clause, SqlQuery sql, object rawValue,
@@ -285,8 +323,29 @@ namespace Searchlight
             var escapeCommand = dialect == SqlDialect.MicrosoftSqlServer ? " ESCAPE '\\'" : string.Empty;
             var notCommand = clause.Negated ? "NOT " : "";
             var likeValue = prefix + EscapeLikeValue(stringValue) + suffix;
-            return
-                $"{clause.Column.OriginalName} {notCommand}{likeCommand} {sql.AddParameter(likeValue, clause.Column.FieldType)}{escapeCommand}";
+
+            if (!sql.Syntax?.Source?.Engine?.CaseSensitiveComparison ?? true)
+                return
+                    $"{clause.Column.OriginalName} {notCommand}{likeCommand} {sql.AddParameter(likeValue, clause.Column.FieldType)}{escapeCommand}";
+
+            switch (dialect)
+            {
+                case SqlDialect.MySql:
+                    return
+                        $"{clause.Column.OriginalName} {notCommand}{likeCommand} BINARY {sql.AddParameter(likeValue, clause.Column.FieldType)}{escapeCommand}";
+                case SqlDialect.MicrosoftSqlServer:
+                    if (string.IsNullOrEmpty(sql.Syntax?.Source?.Engine?.Collation))
+                    {
+                        throw new InvalidEngineSetting(nameof(SearchlightEngine.Collation));
+                    }
+
+                    return
+                        $"{clause.Column.OriginalName} {notCommand}{likeCommand} {sql.AddParameter(likeValue, clause.Column.FieldType)}{escapeCommand} COLLATE {sql.Syntax.Source.Engine.Collation}";
+                case SqlDialect.PostgreSql:
+                default:
+                    return
+                        $"{clause.Column.OriginalName} {notCommand}{likeCommand} {sql.AddParameter(likeValue, clause.Column.FieldType)}{escapeCommand}";
+            }
         }
 
         private static string EscapeLikeValue(string stringValue)

--- a/tests/Searchlight.Tests/Executors/EmployeeTestSuite.cs
+++ b/tests/Searchlight.Tests/Executors/EmployeeTestSuite.cs
@@ -16,6 +16,7 @@ namespace Searchlight.Tests.Executors
         private readonly DataSource _src;
         private readonly List<EmployeeObj> _list;
         private readonly Func<SyntaxTree, Task<FetchResult<EmployeeObj>>> _executor;
+        private readonly StringComparison _comparison;
 
         private EmployeeTestSuite(DataSource src, List<EmployeeObj> list,
             Func<SyntaxTree, Task<FetchResult<EmployeeObj>>> executor)
@@ -23,6 +24,7 @@ namespace Searchlight.Tests.Executors
             _src = src;
             _list = list;
             _executor = executor;
+            _comparison = src?.Engine?.StringComparison ?? StringComparison.OrdinalIgnoreCase;
         }
 
         /// <summary>
@@ -73,6 +75,23 @@ namespace Searchlight.Tests.Executors
             await suite.GreaterThanQuery();
             await suite.GreaterThanOrEqualQuery();
             await suite.StringEqualsCaseInsensitive();
+        }
+        
+        /// <summary>
+        /// Validates correctness of this executor's ability to execute case insensitive string comparisons
+        /// </summary>
+        /// <param name="src"></param>
+        /// <param name="list"></param>
+        /// <param name="executor"></param>
+        public static async Task CaseSensitiveStringTestSuite(DataSource src, List<EmployeeObj> list,
+            Func<SyntaxTree, Task<FetchResult<EmployeeObj>>> executor)
+        {
+            var suite = new EmployeeTestSuite(src, list, executor);
+            await suite.LessThanOrEqualQuery(true);
+            await suite.LessThanQuery(true);
+            await suite.GreaterThanQuery(true);
+            await suite.GreaterThanOrEqualQuery(true);
+            await suite.StringEqualsCaseSensitive();
         }
 
         private async Task QueryListCollection()
@@ -199,7 +218,7 @@ namespace Searchlight.Tests.Executors
             Assert.AreEqual(2, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(e.name.EndsWith("s", StringComparison.OrdinalIgnoreCase));
+                Assert.IsTrue(e.name.EndsWith("s", _comparison));
             }
         }
 
@@ -218,7 +237,7 @@ namespace Searchlight.Tests.Executors
             Assert.AreEqual(9, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(e != null && e.name.Contains('s', StringComparison.OrdinalIgnoreCase));
+                Assert.IsTrue(e != null && e.name.Contains('s', _comparison));
             }
 
             // Now test the opposite
@@ -228,7 +247,7 @@ namespace Searchlight.Tests.Executors
             foreach (var e in results.records)
             {
                 Assert.IsTrue(
-                    e != null && (e.name == null || !e.name.Contains('s', StringComparison.OrdinalIgnoreCase)));
+                    e != null && (e.name == null || !e.name.Contains('s', _comparison)));
             }
             
             // Test for the presence of special characters that might cause problems for parsing
@@ -241,77 +260,81 @@ namespace Searchlight.Tests.Executors
             }
         }
 
-        private async Task GreaterThanQuery()
+        private async Task GreaterThanQuery(bool caseSensitive = false)
         {
-            var syntax = _src.Parse("name gt 'b'");
+            var parameter = caseSensitive ? "B" : "b";
+            var syntax = _src.Parse($"name gt '{parameter}'");
             Assert.AreEqual(1, syntax.Filter.Count);
             Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
             Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
             Assert.AreEqual(OperationType.GreaterThan, ((CriteriaClause)syntax.Filter[0]).Operation);
-            Assert.AreEqual("b", ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
+            Assert.AreEqual(parameter, ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
 
             // Execute the query and ensure that each result matches
             var results = await _executor(syntax);
             Assert.AreEqual(8, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name, "b", StringComparison.CurrentCultureIgnoreCase) > 0);
+                Assert.IsTrue(string.Compare(e.name, parameter, _comparison) > 0);
             }
         }
-
-        private async Task GreaterThanOrEqualQuery()
+        
+        private async Task GreaterThanOrEqualQuery(bool caseSensitive = false)
         {
-            var syntax = _src.Parse("name ge 'bob rogers'");
+            var parameter = caseSensitive ? "Bob Rogers" : "bob rogers";
+            var syntax = _src.Parse($"name ge '{parameter}'");
             Assert.AreEqual(1, syntax.Filter.Count);
             Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
             Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
             Assert.AreEqual(OperationType.GreaterThanOrEqual, ((CriteriaClause)syntax.Filter[0]).Operation);
-            Assert.AreEqual("bob rogers", ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
+            Assert.AreEqual(parameter, ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
 
             // Execute the query and ensure that each result matches
             var results = await _executor(syntax);
             Assert.AreEqual(7, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name[.."bob rogers".Length], "bob rogers",
-                    StringComparison.CurrentCultureIgnoreCase) >= 0);
+                Assert.IsTrue(string.Compare(e.name[..parameter.Length], parameter,
+                    _comparison) >= 0);
             }
         }
 
-        private async Task LessThanQuery()
+        private async Task LessThanQuery(bool caseSensitive = false)
         {
-            var syntax = _src.Parse("name lt 'b'");
+            var parameter = caseSensitive ? "B" : "b";
+            var syntax = _src.Parse($"name lt '{parameter}'");
             Assert.AreEqual(1, syntax.Filter.Count);
             Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
             Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
             Assert.AreEqual(OperationType.LessThan, ((CriteriaClause)syntax.Filter[0]).Operation);
-            Assert.AreEqual("b", ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
+            Assert.AreEqual(parameter, ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
 
             // Execute the query and ensure that each result matches
             var results = await _executor(syntax);
             Assert.AreEqual(1, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name, "b", StringComparison.CurrentCultureIgnoreCase) < 0);
+                Assert.IsTrue(string.Compare(e.name, parameter, _comparison) < 0);
             }
         }
 
-        private async Task LessThanOrEqualQuery()
+        private async Task LessThanOrEqualQuery(bool caseSensitive = false)
         {
-            var syntax = _src.Parse("name le 'bob rogers'");
+            var parameter = caseSensitive ? "Bob Rogers" : "bob rogers";
+            var syntax = _src.Parse($"name le '{parameter}'");
             Assert.AreEqual(1, syntax.Filter.Count);
             Assert.AreEqual(ConjunctionType.NONE, syntax.Filter[0].Conjunction);
             Assert.AreEqual("name", ((CriteriaClause)syntax.Filter[0]).Column.FieldName);
             Assert.AreEqual(OperationType.LessThanOrEqual, ((CriteriaClause)syntax.Filter[0]).Operation);
-            Assert.AreEqual("bob rogers", ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
+            Assert.AreEqual(parameter, ((CriteriaClause)syntax.Filter[0]).Value.GetValue());
 
             // Execute the query and ensure that each result matches
             var results = await _executor(syntax);
             Assert.AreEqual(3, results.records.Length);
             foreach (var e in results.records)
             {
-                Assert.IsTrue(string.Compare(e.name[.."bob rogers".Length], "bob rogers",
-                    StringComparison.CurrentCultureIgnoreCase) <= 0);
+                Assert.IsTrue(string.Compare(e.name[..parameter.Length], parameter,
+                    _comparison) <= 0);
             }
         }
 
@@ -414,6 +437,22 @@ namespace Searchlight.Tests.Executors
             Assert.IsFalse(result.records.Any(p => p.name == "Alice Smith"));
             Assert.IsNotNull(result);
             Assert.AreEqual(_list.Count - 1, result.records.Length);
+        }
+        
+        private async Task StringEqualsCaseSensitive()
+        {
+            var syntax = _src.Parse("name eq 'ALICE SMITH'");
+            var result = await _executor(syntax);
+
+            Assert.IsFalse(result.records.Any(p => p.name == "Alice Smith"));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.records.Length);
+            
+            syntax = _src.Parse("name eq 'Alice Smith'");
+            result = await _executor(syntax);
+            Assert.IsTrue(result.records.Any(p => p.name == "Alice Smith"));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.records.Length);
         }
 
         private async Task DefinedDateOperators()

--- a/tests/Searchlight.Tests/Executors/LinqExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/LinqExecutorTests.cs
@@ -40,6 +40,12 @@ namespace Searchlight.Tests.Executors
         {
             await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _linq);
             await Executors.EmployeeTestSuite.CaseInsensitiveStringTestSuite(_src, _list, _linq);
+
+            _src.Engine = new SearchlightEngine { StringComparison = StringComparison.OrdinalIgnoreCase };
+            await Executors.EmployeeTestSuite.CaseInsensitiveStringTestSuite(_src, _list, _linq);
+            
+            _src.Engine = new SearchlightEngine { StringComparison = StringComparison.Ordinal };
+            await Executors.EmployeeTestSuite.CaseSensitiveStringTestSuite(_src, _list, _linq);
         }
         
         // =========================================================

--- a/tests/Searchlight.Tests/Executors/MysqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/MysqlExecutorTests.cs
@@ -113,5 +113,8 @@ public class MysqlExecutorTests
     public async Task EmployeeTestSuite()
     {
         await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _executor);
+
+        _src.Engine = new SearchlightEngine { StringComparison = StringComparison.Ordinal };
+        await Executors.EmployeeTestSuite.CaseSensitiveStringTestSuite(_src, _list, _executor);
     }
 }

--- a/tests/Searchlight.Tests/Executors/PostgresExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/PostgresExecutorTests.cs
@@ -141,5 +141,8 @@ public class PostgresExecutorTests
     public async Task EmployeeTestSuite()
     {
         await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _executor);
+        
+        _src.Engine = new SearchlightEngine { StringComparison = StringComparison.Ordinal };
+        await Executors.EmployeeTestSuite.CaseSensitiveStringTestSuite(_src, _list, _executor);
     }
 }

--- a/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
@@ -154,5 +154,12 @@ public class SqlServerExecutorTests
     public async Task EmployeeTestSuite()
     {
         await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _postgres);
+        
+        _src.Engine = new SearchlightEngine
+        {
+            StringComparison = StringComparison.Ordinal,
+            Collation = "SQL_Latin1_General_CP1_CS_AS"
+        };
+        await Executors.EmployeeTestSuite.CaseSensitiveStringTestSuite(_src, _list, _postgres);
     }
 }


### PR DESCRIPTION
# Changes
- Add `StringComparison` field to use .NET enum
  - The actual object is only used for LINQ, the `CaseSensitiveComparison` is determined from this field
- Add to `SqlExecutor` to use case sensitive queries dependent on language

Let me know if there is a more intuitive approach for how to set this up, it works for now but I think it can be cleaned up a bit. I left Mongo alone for now, I'm not sure how to handle that yet. 

Resolves #126 