### PR TITLE
Switch SonarScanner to automated mode

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,31 +16,13 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-    - name: Check Environment Variables (RUNNER_TEMP)
-      run: echo "Runner Temp is ${{env.RUNNER_TEMP}}"
-    - name: Check Environment Variables (TMP)
-      env: 
-        TMP: ${{env.RUNNER_TEMP}}
-      run: echo "DotNet TMP is ${{env.TMP}}"
+        dotnet-version: 7.0.x
     - name: Restore
       run: dotnet restore
-    - name: SonarCloud Install
-      run:
-        dotnet tool update dotnet-sonarscanner --tool-path /tmp/sonar
-    - name: Coverage Install
-      run:
-        dotnet tool update dotnet-coverage --tool-path /tmp/coverage
-    - name: SonarCloud Start
-      run:
-        /tmp/sonar/dotnet-sonarscanner begin /k:"tspence_csharp-searchlight" /o:"tspence" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
     - name: Build
       run: dotnet build
     - name: Test
-      env: 
-        TMP: /tmp
-      run:
-        /tmp/coverage/dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
-    - name: SonarCloud End
-      run:
-        /tmp/sonar/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+      run: dotnet test
+ 
+  # We no longer use SonarCloud here; SonarCloud does automated scanning instead.  
+  # This means we don't get code coverage but it is much faster and simpler.

--- a/src/SearchlightPerformance/SearchlightPerformance.csproj
+++ b/src/SearchlightPerformance/SearchlightPerformance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>disable</Nullable>
         <RootNamespace>perftest</RootNamespace>
         <OutputType>Exe</OutputType>

--- a/tests/Searchlight.Tests/Searchlight.Tests.csproj
+++ b/tests/Searchlight.Tests/Searchlight.Tests.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes sonar scanner from the github action.  From recent experience, I believe Sonar works better on its own.  This means we lose the official code coverage numbers from Sonar but I'll live with that.