### PR TITLE
Use EnumMember values when present

### DIFF
--- a/src/Searchlight/Attributes/SearchlightField.cs
+++ b/src/Searchlight/Attributes/SearchlightField.cs
@@ -44,5 +44,14 @@ namespace Searchlight
         ///   - Is (Not) Null
         /// </summary>
         public bool IsJson { get; set; } = false;
+        
+        /// <summary>
+        /// (optional) Set to true if the database column is encrypted.
+        /// 
+        /// If the column is encrypted, the Searchlight engine will use the provided ISearchlightStringEncryptor to encrypt the value before querying.
+        /// The column must be of type string.
+        /// Encrypted columns can only use equality, nullity, or in operators.
+        /// </summary>
+        public bool IsEncrypted { get; set; } = false;
     }
 }

--- a/src/Searchlight/Attributes/SearchlightField.cs
+++ b/src/Searchlight/Attributes/SearchlightField.cs
@@ -32,5 +32,17 @@ namespace Searchlight
         /// (optional) If you wish to use Searchlight autocomplete, you can provide a documentation block here.
         /// </summary>
         public string Description { get; set; }
+        
+        /// <summary>
+        /// (optional) Set to true if the database column is storing JSON.
+        ///
+        /// Current limitations of using JSON columns include:
+        /// - No filtering/sorting on JSON arrays
+        /// - Supported operators are:
+        ///   - (Not) Equals
+        ///   - (Not) In
+        ///   - Is (Not) Null
+        /// </summary>
+        public bool IsJson { get; set; } = false;
     }
 }

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -65,22 +65,21 @@ namespace Searchlight
         /// <returns></returns>
         public DataSource WithColumn(string columnName, Type columnType)
         {
-            return WithRenamingColumn(columnName, columnName, null, columnType, null, null);
+            return WithRenamingColumn(new ColumnInfo(columnName, columnName, null, columnType, null, null, false));
         }
 
         /// <summary>
         /// Add a column to this definition
         /// </summary>
-        public DataSource WithRenamingColumn(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description)
+        public DataSource WithRenamingColumn(ColumnInfo columnInfo)
         {
-            var columnInfo = new ColumnInfo(filterName, columnName, aliases, columnType, enumType, description);
             _columns.Add(columnInfo);
 
             // Allow the API caller to either specify either the model name or one of the aliases
-            AddName(filterName, columnInfo);
-            if (aliases != null)
+            AddName(columnInfo.FieldName, columnInfo);
+            if (columnInfo.Aliases != null)
             {
-                foreach (var alias in aliases)
+                foreach (var alias in columnInfo.Aliases)
                 {
                     AddName(alias, columnInfo);
                 }
@@ -203,7 +202,7 @@ namespace Searchlight
                             var t = filter.FieldType ?? pi.PropertyType;
                             var columnName = filter.OriginalName ?? pi.Name;
                             var aliases = filter.Aliases ?? Array.Empty<string>();
-                            src.WithRenamingColumn(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description);
+                            src.WithRenamingColumn(new ColumnInfo(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson));
                         }
 
                         var collection = pi.GetCustomAttributes<SearchlightCollection>().FirstOrDefault();

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -65,7 +65,7 @@ namespace Searchlight
         /// <returns></returns>
         public DataSource WithColumn(string columnName, Type columnType)
         {
-            return WithRenamingColumn(new ColumnInfo(columnName, columnName, null, columnType, null, null, false));
+            return WithRenamingColumn(new ColumnInfo(columnName, columnName, null, columnType, null, null, false, false));
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Searchlight
                             var t = filter.FieldType ?? pi.PropertyType;
                             var columnName = filter.OriginalName ?? pi.Name;
                             var aliases = filter.Aliases ?? Array.Empty<string>();
-                            src.WithRenamingColumn(new ColumnInfo(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson));
+                            src.WithRenamingColumn(new ColumnInfo(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson, filter.IsEncrypted));
                         }
 
                         var collection = pi.GetCustomAttributes<SearchlightCollection>().FirstOrDefault();

--- a/src/Searchlight/Encryption/ISearchlightStringEncryptor.cs
+++ b/src/Searchlight/Encryption/ISearchlightStringEncryptor.cs
@@ -1,0 +1,15 @@
+namespace Searchlight.Encryption
+{
+    /// <summary>
+    /// An interface for encrypting strings prior to being used in a query filter.
+    /// </summary>
+    public interface ISearchlightStringEncryptor
+    {
+        /// <summary>
+        /// A method to encrypt a string using the same algorithm used to store the encrypted data.
+        /// </summary>
+        /// <param name="plainText"></param>
+        /// <returns></returns>
+        string Encrypt(string plainText);
+    }
+}

--- a/src/Searchlight/Exceptions/InvalidOperation.cs
+++ b/src/Searchlight/Exceptions/InvalidOperation.cs
@@ -1,0 +1,23 @@
+#pragma warning disable CS1591
+namespace Searchlight.Exceptions
+{
+    /// <summary>
+    /// The operation used in the filter on a given field is not supported.
+    ///
+    /// Example: `(someField gt 5)` where `someField` is an encrypted field.
+    /// </summary>
+    public class InvalidOperation : SearchlightException
+    {
+        public string OriginalFilter { get; internal set; }
+
+        public string FieldName { get; internal set; }
+
+        public string Operation { get; internal set; }
+
+        public string ErrorMessage
+        {
+            get =>
+                $"The query filter, {OriginalFilter}, uses {Operation} on {FieldName} which is not supported.";
+        }
+    }
+}

--- a/src/Searchlight/Exceptions/UnterminatedJsonKey.cs
+++ b/src/Searchlight/Exceptions/UnterminatedJsonKey.cs
@@ -1,0 +1,28 @@
+﻿#pragma warning disable CS1591
+namespace Searchlight
+{
+    /// <summary>
+    /// A filter statement contained an unterminated JSON key.  An opening double quote was observed but the remainder
+    /// of the string did not contain a closing quote.
+    ///
+    /// Example: (dimensions."address is not null)
+    /// </summary>
+    public class UnterminatedJsonKey : SearchlightException
+    {
+        public string OriginalFilter { get; internal set; }
+        public int StartPosition { get; internal set; }
+        public ParsingType ParsingType { get; internal set; }
+
+        public string ErrorMessage
+        {
+            get =>
+                $"The query {(ParsingType == ParsingType.Filter ? "filter" : "order by")}, {OriginalFilter}, contained an unterminated JSON Key that starts at {StartPosition}. JSON Keys should be in the format .\"{{KeyName}}\"";
+        }
+    }
+
+    public enum ParsingType
+    {
+        Filter,
+        OrderBy
+    }
+}

--- a/src/Searchlight/Parsing/ColumnInfo.cs
+++ b/src/Searchlight/Parsing/ColumnInfo.cs
@@ -17,7 +17,8 @@ namespace Searchlight.Parsing
         /// <param name="enumType">The type of the enum that the column is mapped to</param>
         /// <param name="description">A description of the column for autocomplete</param>
         /// <param name="isJson"></param>
-        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson)
+        /// <param name="isEncrypted">Is the column an encrypted column</param>
+        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson, bool isEncrypted)
         {
             FieldName = filterName;
             OriginalName = columnName;
@@ -31,6 +32,12 @@ namespace Searchlight.Parsing
             EnumType = enumType;
             Description = description;
             IsJson = isJson;
+
+            if(isEncrypted && columnType != typeof(string))
+            {
+                throw new ArgumentException($"Field {FieldName} is marked as encrypted but is not of type string. Encrypted columns must be of type string", nameof(isEncrypted));
+            }
+            IsEncrypted = isEncrypted;
         }
 
         /// <summary>
@@ -68,5 +75,10 @@ namespace Searchlight.Parsing
         /// (optional) Set to true if the database column is storing JSON.
         /// </summary>
         public bool IsJson { get; set; } = false;
+        
+        /// <summary>
+        /// (optional) Set to true if the database column is encrypted.
+        /// </summary>
+        public bool IsEncrypted { get; set; } = false;
     }
 }

--- a/src/Searchlight/Parsing/ColumnInfo.cs
+++ b/src/Searchlight/Parsing/ColumnInfo.cs
@@ -16,7 +16,8 @@ namespace Searchlight.Parsing
         /// <param name="columnType">The raw type of the column in the database</param>
         /// <param name="enumType">The type of the enum that the column is mapped to</param>
         /// <param name="description">A description of the column for autocomplete</param>
-        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description)
+        /// <param name="isJson"></param>
+        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson)
         {
             FieldName = filterName;
             OriginalName = columnName;
@@ -29,6 +30,7 @@ namespace Searchlight.Parsing
 
             EnumType = enumType;
             Description = description;
+            IsJson = isJson;
         }
 
         /// <summary>
@@ -61,5 +63,10 @@ namespace Searchlight.Parsing
         /// Detailed field documentation for autocomplete, if provided.
         /// </summary>
         public string Description { get; private set; }
+
+        /// <summary>
+        /// (optional) Set to true if the database column is storing JSON.
+        /// </summary>
+        public bool IsJson { get; set; } = false;
     }
 }

--- a/src/Searchlight/Parsing/SyntaxParser.cs
+++ b/src/Searchlight/Parsing/SyntaxParser.cs
@@ -146,6 +146,18 @@ namespace Searchlight.Parsing
 
             // Okay, let's tokenize the orderBy statement and begin parsing
             var tokens = Tokenizer.GenerateTokens(orderBy);
+            
+            if (tokens.HasUnterminatedJsonKeyName)
+            {
+                syntax.AddError(new UnterminatedJsonKey()
+                {
+                    OriginalFilter = orderBy,
+                    StartPosition = tokens.LastJsonKeyBegin,
+                    ParsingType = ParsingType.OrderBy
+                });
+                return;
+            }
+            
             while (tokens.TokenQueue.Count > 0)
             {
                 var si = new SortInfo { Direction = SortDirection.Ascending };
@@ -164,10 +176,25 @@ namespace Searchlight.Parsing
 
                 // Was that the last token?
                 if (tokens.TokenQueue.Count == 0) break;
+                
+                // Collect JSON keys for clause if any
+                var nextToken = tokens.TokenQueue.Dequeue();
+                var jsonKeys = new List<string>();
+                while (si.Column != null && si.Column.IsJson && nextToken.Value.StartsWith("\""))
+                {
+                    jsonKeys.Add(nextToken.Value);
+                    
+                    // Was that the last token?
+                    if (tokens.TokenQueue.Count == 0) break;
+                    
+                    nextToken = tokens.TokenQueue.Dequeue();
+                }
+
+                si.JsonKeys = jsonKeys.ToArray();
 
                 // Next, we allow ASC or ASCENDING, DESC or DESCENDING, or a comma (indicating another sort).
                 // First, check for the case of a comma
-                var token = tokens.TokenQueue.Dequeue();
+                var token = nextToken;
                 if (token.Value == StringConstants.COMMA)
                 {
                     if (tokens.TokenQueue.Count == 0)
@@ -222,6 +249,16 @@ namespace Searchlight.Parsing
                 {
                     OriginalFilter = filter,
                     StartPosition = tokens.LastStringLiteralBegin 
+                });
+                return;
+            }
+            if (tokens.HasUnterminatedJsonKeyName)
+            {
+                syntax.AddError(new UnterminatedJsonKey()
+                {
+                    OriginalFilter = filter,
+                    StartPosition = tokens.LastJsonKeyBegin,
+                    ParsingType = ParsingType.Filter
                 });
                 return;
             }
@@ -349,9 +386,18 @@ namespace Searchlight.Parsing
                 return null;
             }
 
+            // Collect JSON keys for clause if any
+            var nextToken = tokens.TokenQueue.Dequeue().Value;
+            var jsonKeys = new List<string>();
+            while (columnInfo.IsJson && nextToken.StartsWith("\""))
+            {
+                jsonKeys.Add(nextToken);
+                nextToken = tokens.TokenQueue.Dequeue().Value;
+            }
+
             // Allow "NOT" tokens here
             var negated = false;
-            var operationToken = tokens.TokenQueue.Dequeue().Value.ToUpperInvariant();
+            var operationToken = nextToken.ToUpperInvariant();
             if (operationToken == StringConstants.NOT)
             {
                 negated = true;
@@ -373,7 +419,8 @@ namespace Searchlight.Parsing
                     {
                         Negated = negated,
                         Column = columnInfo,
-                        LowerValue = ParseParameter(syntax, columnInfo, tokens.TokenQueue.Dequeue().Value, tokens)
+                        LowerValue = ParseParameter(syntax, columnInfo, tokens.TokenQueue.Dequeue().Value, tokens),
+                        JsonKeys = jsonKeys.ToArray()
                     };
                     syntax.Expect(StringConstants.AND, tokens.TokenQueue.Dequeue().Value, tokens.OriginalText);
                     b.UpperValue = ParseParameter(syntax, columnInfo, tokens.TokenQueue.Dequeue().Value, tokens);
@@ -385,7 +432,8 @@ namespace Searchlight.Parsing
                     {
                         Column = columnInfo,
                         Negated = negated,
-                        Values = new List<IExpressionValue>()
+                        Values = new List<IExpressionValue>(),
+                        JsonKeys = jsonKeys.ToArray()
                     };
                     syntax.Expect(StringConstants.OPEN_PARENTHESIS, tokens.TokenQueue.Dequeue().Value, tokens.OriginalText);
 
@@ -408,7 +456,7 @@ namespace Searchlight.Parsing
 
                 // Safe syntax for an "IS NULL" expression is "column IS [NOT] NULL"
                 case OperationType.IsNull:
-                    var iN = new IsNullClause { Column = columnInfo };
+                    var isNull = new IsNullClause { Column = columnInfo };
 
                     // Allow "not" to come either before or after the "IS"
                     var next = tokens.TokenQueue.Dequeue().Value.ToUpperInvariant();
@@ -418,9 +466,10 @@ namespace Searchlight.Parsing
                         next = tokens.TokenQueue.Dequeue().Value;
                     }
 
-                    iN.Negated = negated;
+                    isNull.Negated = negated;
+                    isNull.JsonKeys = jsonKeys.ToArray();
                     syntax.Expect(StringConstants.NULL, next, tokens.OriginalText);
-                    return iN;
+                    return isNull;
 
                 // Safe syntax for all other recognized expressions is "column op param"
                 default:
@@ -430,7 +479,8 @@ namespace Searchlight.Parsing
                         Negated = negated,
                         Operation = op,
                         Column = columnInfo,
-                        Value = ParseParameter(syntax, columnInfo, valueToken.Value, tokens)
+                        Value = ParseParameter(syntax, columnInfo, valueToken.Value, tokens),
+                        JsonKeys = jsonKeys.ToArray()
                     };
 
                     if ((c.Operation == OperationType.StartsWith || c.Operation == OperationType.EndsWith

--- a/src/Searchlight/Parsing/TokenStream.cs
+++ b/src/Searchlight/Parsing/TokenStream.cs
@@ -23,8 +23,18 @@ namespace Searchlight.Parsing
         public bool HasUnterminatedLiteral { get; set; }
         
         /// <summary>
+        /// Set to true if there is an open double quote but no closing double quote
+        /// </summary>
+        public bool HasUnterminatedJsonKeyName { get; set; }
+        
+        /// <summary>
         /// Used to determine where unterminated literal begins
         /// </summary>
         public int LastStringLiteralBegin { get; set; }
+        
+        /// <summary>
+        /// Used to determine where JSON Key begins
+        /// </summary>
+        public int LastJsonKeyBegin { get; set; }
     }
 }

--- a/src/Searchlight/Query/BaseClause.cs
+++ b/src/Searchlight/Query/BaseClause.cs
@@ -1,4 +1,6 @@
-﻿
+﻿using System;
+using Searchlight.Parsing;
+
 namespace Searchlight.Query
 {
     /// <summary>
@@ -6,6 +8,11 @@ namespace Searchlight.Query
     /// </summary>
     public class BaseClause
     {
+        /// <summary>
+        /// The field being tested
+        /// </summary>
+        public ColumnInfo Column { get; set; }
+        
         /// <summary>
         /// This value is true if the result of this test is to be inverted
         /// </summary>
@@ -16,5 +23,10 @@ namespace Searchlight.Query
         /// If this is the last clause, the conjunction is NONE.
         /// </summary>
         public ConjunctionType Conjunction { get; set; }
+
+        /// <summary>
+        /// List of all JSON keys that are being filtered on for this clause
+        /// </summary>
+        public string[] JsonKeys { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/Searchlight/Query/BetweenClause.cs
+++ b/src/Searchlight/Query/BetweenClause.cs
@@ -9,11 +9,6 @@ namespace Searchlight.Query
     public class BetweenClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// Lower value in the between test
         /// </summary>
         public IExpressionValue LowerValue { get; set; }

--- a/src/Searchlight/Query/CriteriaClause.cs
+++ b/src/Searchlight/Query/CriteriaClause.cs
@@ -9,11 +9,6 @@ namespace Searchlight.Query
     public class CriteriaClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// Operation for testing
         /// </summary>
         public OperationType Operation { get; set; }

--- a/src/Searchlight/Query/InClause.cs
+++ b/src/Searchlight/Query/InClause.cs
@@ -10,11 +10,6 @@ namespace Searchlight.Query
     public class InClause : BaseClause
     {
         /// <summary>
-        /// The field to test
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// The list of values to test against
         /// </summary>
         public List<IExpressionValue> Values { get; set; }

--- a/src/Searchlight/Query/IsNullClause.cs
+++ b/src/Searchlight/Query/IsNullClause.cs
@@ -8,11 +8,6 @@ namespace Searchlight.Query
     public class IsNullClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-        
-        /// <summary>
         /// Render this criteria in a readable string
         /// </summary>
         public override string ToString()

--- a/src/Searchlight/Query/SortInfo.cs
+++ b/src/Searchlight/Query/SortInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using Searchlight.Parsing;
 
 namespace Searchlight.Query
@@ -17,6 +18,11 @@ namespace Searchlight.Query
         /// </summary>
         public SortDirection Direction { get; set; }
 
+        /// <summary>
+        /// An array of JSON keys for the sort if any.
+        /// </summary>
+        public string[] JsonKeys { get; set; } = Array.Empty<string>();
+        
         /// <summary>
         /// Convenience to return the abbreviated string for directions
         /// </summary>

--- a/src/Searchlight/Query/SyntaxTree.cs
+++ b/src/Searchlight/Query/SyntaxTree.cs
@@ -32,7 +32,7 @@ namespace Searchlight.Query
         /// <returns>True if this flag is enabled</returns>
         public bool HasFlag(string flagName)
         {
-            return (from f in Flags where String.Equals(f.Name, flagName, StringComparison.CurrentCultureIgnoreCase) select f).Any();
+            return (from f in Flags where string.Equals(f.Name, flagName, StringComparison.CurrentCultureIgnoreCase) select f).Any();
         }
 
         /// <summary>

--- a/src/Searchlight/SearchlightEngine.cs
+++ b/src/Searchlight/SearchlightEngine.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Searchlight.Autocomplete;
+using Searchlight.Encryption;
 using Searchlight.Exceptions;
 using Searchlight.Parsing;
 using Searchlight.Query;
@@ -64,6 +65,11 @@ namespace Searchlight
         /// DEFAULT: True.
         /// </summary>
         public bool useNoCount { get; set; } = true;
+        
+        /// <summary>
+        /// Encryption implementation to use for encrypted fields.
+        /// </summary>
+        public ISearchlightStringEncryptor Encryptor { get; set; } = null;
 
         /// <summary>
         /// Adds a new class to the engine

--- a/src/Searchlight/StringConstants.cs
+++ b/src/Searchlight/StringConstants.cs
@@ -81,6 +81,11 @@ namespace Searchlight
         public static readonly char SINGLE_QUOTE = '\'';
 
         /// <summary>
+        /// Represents a double quote character for tokenization of JSON key names
+        /// </summary>
+        public static readonly char DOUBLE_QUOTE = '"';
+
+        /// <summary>
         /// Represents an open parenthesis character for tokenization of strings
         /// </summary>
         public static readonly string OPEN_PARENTHESIS = "(";
@@ -136,6 +141,16 @@ namespace Searchlight
         /// Used for date math
         /// </summary>
         public static readonly string SUBTRACT = "-";
+
+        /// <summary>
+        /// Used to start JSON keys 
+        /// </summary>
+        public static readonly char DOT = '.';
+
+        /// <summary>
+        /// Used for escape characters 
+        /// </summary>
+        public static readonly char BACKSLASH = '\\';
 
         /// <summary>
         /// Used as shorthand for typing today's date

--- a/tests/Searchlight.Tests/Models/EmployeeObj.cs
+++ b/tests/Searchlight.Tests/Models/EmployeeObj.cs
@@ -37,6 +37,9 @@ public class EmployeeObj
     [BsonRepresentation(BsonType.Int32)]
     [SearchlightField(FieldType = typeof(int), EnumType = typeof(EmployeeType))]
     public EmployeeType employeeType { get; set; }
+    
+    [SearchlightField(FieldType = typeof(string), IsJson = true)]
+    public Dictionary<string, object> dims { get; set; }
 
     public static List<EmployeeObj> GetTestList()
     {
@@ -50,6 +53,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m, 
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object> { {"test <> test", "value"} }
             },
             new()
             {
@@ -59,6 +63,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m,
                 employeeType = EmployeeType.PartTime,
+                dims = new Dictionary<string, object> { {"test", "value"} }
             },
             new()
             {
@@ -68,6 +73,7 @@ public class EmployeeObj
                 onduty = false,
                 paycheck = 800.0m,
                 employeeType = EmployeeType.Contract,
+                dims = new Dictionary<string, object> { {"test", "value"} }
             },
             new()
             {
@@ -77,6 +83,7 @@ public class EmployeeObj
                 onduty = false,
                 paycheck = 1200.0m,
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object>{{"test", new Dictionary<string, object>{{"inner", "balue"}}}}
             },
             new()
             {
@@ -86,6 +93,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m,
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object>{{"test", new Dictionary<string, object>{{"inner", "value"}}}}
             },
             new()
             {

--- a/tests/Searchlight.Tests/SqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/SqlExecutorTests.cs
@@ -224,13 +224,13 @@ namespace Searchlight.Tests
             Assert.AreEqual(123456789123456, sql.Parameters["@p1"]);
 
             // Test the guid
-            query = _source.ParseFilter(String.Format("colguid eq '{0}'", Guid.Empty.ToString()));
+            query = _source.ParseFilter(string.Format("colguid eq '{0}'", Guid.Empty.ToString()));
             sql = query.ToSqlServerCommand();
             Assert.AreEqual("colGuid = @p1", sql.WhereClause.ToString());
             Assert.AreEqual(Guid.Empty, sql.Parameters["@p1"]);
 
             // Test the nullable guid
-            query = _source.ParseFilter(String.Format("colNullableGuid is null or colNullableGuid = '{0}'",
+            query = _source.ParseFilter(string.Format("colNullableGuid is null or colNullableGuid = '{0}'",
                 Guid.Empty.ToString()));
             sql = query.ToSqlServerCommand();
             Assert.AreEqual("colNullableGuid IS NULL OR colNullableGuid = @p1", sql.WhereClause.ToString());

--- a/tests/Searchlight.Tests/TokenizerTests.cs
+++ b/tests/Searchlight.Tests/TokenizerTests.cs
@@ -23,7 +23,7 @@ namespace Searchlight.Tests
         {
             // Parse a date time pattern
             string date = DateTime.UtcNow.ToString("yyyy-MM-dd");
-            string filters = String.Format("EffectiveDate > '{0}' OR MaintenanceDate > '{0}' OR TotalSalesEffDate > '{0}' OR SalesEffDate > '{0}' OR UseEffDate > '{0}'", date);
+            string filters = string.Format("EffectiveDate > '{0}' OR MaintenanceDate > '{0}' OR TotalSalesEffDate > '{0}' OR SalesEffDate > '{0}' OR UseEffDate > '{0}'", date);
             var list = Tokenizer.GenerateTokens(filters).TokenQueue.ToList();
             Assert.AreEqual(19, list.Count);
             Assert.AreEqual("EffectiveDate", list[0].Value);


### PR DESCRIPTION
Updated parsing to accept EnumMember values when available. Also updated error message to report EnumMember values as the intended filter value if an incorrect value is provided.